### PR TITLE
👷 Only issue slack notif upon repository dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
       - uses: voxmedia/github-action-slack-notify-build@v1
-        if: success()
+        if: ${{ success() && github.event_name == 'repository_dispatch' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_GITHUB_ACTION }}
         with:
@@ -97,7 +97,7 @@ jobs:
           color: good
 
       - uses: voxmedia/github-action-slack-notify-build@v1
-        if: failure()
+        if: ${{ failure() && github.event_name == 'repository_dispatch' }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_GITHUB_ACTION }}
         with:


### PR DESCRIPTION
Currently getting loads of notifs that are only supposed to be triggered when running integration tests before a lamindb release through repository dispatch.

<img width="679" alt="image" src="https://github.com/user-attachments/assets/9100e7c7-30a3-41d6-9026-a5cdedeaf130" />
