### PR TITLE
🔈 Make logging consistent with other Lamin packages

### DIFF
--- a/src/main/groovy/ai/lamin/nf_lamin/LaminObserver.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminObserver.groovy
@@ -161,9 +161,9 @@ class LaminObserver implements TraceObserver {
         String instanceString = "${this.instance.getOwner()}/${this.instance.getName()}"
         try {
             Map account = this.instance.getAccount()
-            log.info "✅ Connected to LaminDB instance '${instanceString}' as '${account.handle}'"
+            log.info "→ connected lamindb: '${instanceString}' as '${account.handle}'"
         } catch (ApiException e) {
-            log.error "❌ Could not connect to LaminDB instance '${instanceString}'!"
+            log.error "✗ Could not connect lamindb: '${instanceString}'!"
             log.error 'API call failed: ' + e.getMessage()
         }
     }


### PR DESCRIPTION
Just a detail that struck me: The icon, capitalization and wording was inconsistent with the rest of the Lamin tools.

These are our icons: https://github.com/laminlabs/lamin-utils/blob/2a2c54522565f8d043686c247868718dfb6fb0da/lamin_utils/_logger.py#L74

This is the "connected" log message: https://github.com/laminlabs/lamindb-setup/blob/ed709d557e27b4fd1006fc28b134e1531f917ec0/lamindb_setup/_connect_instance.py#L258

