### PR TITLE
🐛 Fill in `null`s in generated Transform metadata

### DIFF
--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -254,8 +254,8 @@ final class LaminRunManager {
             return transformRecord
         }
 
-        String manifestName = wfMetadata.manifest.getName() ?: '<No name in manifest>'
-        String manifestDescription = wfMetadata.manifest.getDescription() ?: '<No description in manifest>'
+        String manifestName = wfMetadata.manifest.getName() ?: '<no name in manifest>'
+        String manifestDescription = wfMetadata.manifest.getDescription() ?: '<no description in manifest>'
         String description = "${manifestName}: ${manifestDescription}"
         String commitId = wfMetadata.commitId
         Map info = [


### PR DESCRIPTION
This PR adds some more defaults such that if certain values are not filled in, the transform that gets created doesn't have description `"bgzip: null"` but instead `"bgzip: <no description in manifest>"`.