### PR TITLE
💚 Split CI to avoid confusion about what is failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       - "*"
   repository_dispatch:
     types: [build]
+  # run tests daily at 5am UTC (not publish)
+  schedule:
+    - cron: "0 5 * * *"
 
 jobs:
   lint:
@@ -198,7 +201,7 @@ jobs:
     name: Publish docs
     runs-on: ubuntu-latest
     needs: [lint, test, build]
-    if: ${{ always() && contains(needs.build.result, 'success') }}
+    if: ${{ always() && contains(needs.build.result, 'success') && github.event_name != 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Before, `Test nf-lamin` was being run with matrix:

* java version: 21
* java version: 25, with report

However this was actually doing three things:

* Lint if java_version == 25
* Run unit tests on both production and staging
* Run the validation wf on production

This can be confusing, since for instance this would cause the testing to fail on java version 25 if there was a linting error.

This PR changes the setup so instead the following things are run separately:

* Lint (separate job)
* Test (unit tests and validation) on java 21 and staging
* Test (unit tests and validation) on java 21 and prod
* Test (unit tests and validation) on java 25 and staging
* Test (unit tests and validation) on java 25 and prod

This will allow to more easily identify what's going wrong when something fails