### PR TITLE
:bug: Fix assets directory detection

### DIFF
--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import nextflow.Const
 import nextflow.Session
 import nextflow.file.FileHelper
 import nextflow.script.WorkflowMetadata
@@ -965,14 +966,16 @@ final class LaminRunManager {
     }
 
     /**
-     * Check if a path is within ~/.nextflow/assets.
+     * Check if a path is within the Nextflow assets directory.
+     *
+     * Respects NXF_ASSETS and NXF_HOME env vars via nextflow.Const.DEFAULT_ROOT.
      */
     private boolean isInAssetsDir(Path path) {
-        String homeDir = System.getProperty('user.home')
-        if (homeDir == null || homeDir.trim().isEmpty()) {
+        File assetsRoot = Const.DEFAULT_ROOT
+        if (assetsRoot == null) {
             return false
         }
-        Path assetsDir = Path.of(homeDir, '.nextflow', 'assets')
+        Path assetsDir = assetsRoot.toPath()
         return isInDir(path, assetsDir, 'assets')
     }
 

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
@@ -71,7 +71,7 @@ class ArtifactConfig {
     final Boolean excludeWorkDir
 
     /**
-     * Whether to exclude artifacts in ~/.nextflow/assets (default: true).
+     * Whether to exclude artifacts in the Nextflow assets directory (default: true).
      * Pipeline source files live here.
      */
     final Boolean excludeAssetsDir


### PR DESCRIPTION
Fixes pfizer-collab/laminlabs#769

`isInAssetsDir` was hardcoded to `$HOME/.nextflow/assets`, so users with a custom `NXF_HOME` or `NXF_ASSETS` would see pipeline assets incorrectly tracked as artifacts.

Fixed by using `nextflow.Const.DEFAULT_ROOT`, which applies the same resolution logic Nextflow itself uses (`NXF_ASSETS` → `$NXF_HOME/assets` → `$HOME/.nextflow/assets`).
