### PR TITLE
:bug: Defer param evaluation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.nextflow.nextflow-plugin' version '1.0.0-beta.10'
 }
 
-version = '0.6.1'
+version = '0.6.2'
 
 repositories {
     mavenCentral()

--- a/configs/testing.config
+++ b/configs/testing.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {

--- a/configs/testing.config
+++ b/configs/testing.config
@@ -1,5 +1,5 @@
 plugins {
-  id 'nf-lamin@0.6.0'
+  id 'nf-lamin@0.6.1'
 }
 
 lamin {

--- a/docs/nextflow-plugin-reference.md
+++ b/docs/nextflow-plugin-reference.md
@@ -318,7 +318,7 @@ lamin {
     // For example, with --outdir /home/user/results/:
     //   /home/user/results/multiqc/star/multiqc_report.html
     //   → multiqc/star/multiqc_report.html
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
   }
 }
 ```

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -31,7 +31,7 @@ lamin {
 
   // Track output artifacts, stripping the outdir prefix from keys
   output_artifacts {
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
     exclude_pattern = '.*'
     rules {
       // Enabled by default
@@ -119,7 +119,7 @@ The `key` option controls how artifact keys are generated from file paths. By de
 **Map shorthand** (recommended for nf-core-style pipelines):
 
 ```groovy
-key = [relativize: params.outdir]
+key = [relativize: { params.outdir }]
 // /home/user/results/multiqc/report.html → multiqc/report.html
 ```
 
@@ -221,7 +221,7 @@ lamin {
   }
 
   output_artifacts {
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
     exclude_pattern = '.*\\.(log|tmp)$'
     rules {
       exclude_intermediate { type = 'exclude'; pattern = '.*intermediate.*'; order = 1 }

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -123,6 +123,14 @@ key = [relativize: { params.outdir }]
 // /home/user/results/multiqc/report.html → multiqc/report.html
 ```
 
+`relativize` strips the given directory prefix from each artifact path, preserving the subdirectory structure as the key. It is equivalent to writing `key = { path -> path.toString().removePrefix(params.outdir + '/') }` but handles `file://`, `s3://`, `gs://`, and other URI schemes uniformly. If an artifact path falls outside the base directory, the plugin falls back to the basename.
+
+The `relativize` value accepts either a plain string or a closure. Wrapping it in a closure (`{ params.outdir }` instead of `params.outdir`) is **strongly recommended** when using `params`: it delays evaluation until the workflow runs. Without the closure, Nextflow resolves the expression at config-parse time, and on Seqera Cloud (e.g. with `-with-tower`) this raises an error such as:
+
+```
+ERROR ~ Unknown config attribute `lamin.output_artifacts.params.outdir` -- check config file
+```
+
 **String template** with variables:
 
 - `{basename}`: filename with extension
@@ -178,7 +186,22 @@ input_artifacts {
 ```
 
 :::{note}
-Wrap `include_paths` in a closure (`{ ... }`) when accessing `params`, because `params` are not fully resolved at config parse time. Writing `include_paths = params.input` directly will cause an error.
+Always wrap `include_paths` in a closure (`{ ... }`) when referencing `params`. Locally, `include_paths = params.input` may work, but on Seqera Cloud (e.g. with `-with-tower`) Nextflow resolves config expressions at parse time and raises an error such as:
+
+```
+ERROR ~ Unknown config attribute `lamin.input_artifacts.params.input` -- check config file
+```
+
+The same applies to interpolated path lists:
+
+```groovy
+// ❌ Fails on Seqera Cloud
+include_paths = ["${params.outdir}/samplesheet/samplesheet.csv"]
+
+// ✅ Safe everywhere
+include_paths = { ["${params.outdir}/samplesheet/samplesheet.csv"] }
+```
+
 :::
 
 Input paths are resolved at the beginning of the workflow (`onFlowBegin`), and output paths just before finalizing the run. Resolved paths go through the same deduplication, metadata linking, and rule evaluation as auto-detected artifacts.

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -52,7 +52,7 @@ lamin {
 
   output_artifacts {
     enabled = true
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
     exclude_pattern = '.*'
     rules {
       // Enabled by default
@@ -120,7 +120,7 @@ lamin {
 
   output_artifacts {
     enabled = true
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
     exclude_pattern = '.*'
     rules {
       // Enabled by default
@@ -189,7 +189,7 @@ lamin {
 
   output_artifacts {
     enabled = true
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
     exclude_pattern = '.*'
     rules {
       // Enabled by default

--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -33,7 +33,7 @@ The [`examples/rnaseq/nextflow.config`](https://github.com/laminlabs/nf-lamin/bl
 
 ```groovy
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {
@@ -101,7 +101,7 @@ The [`examples/scrnaseq/nextflow.config`](https://github.com/laminlabs/nf-lamin/
 
 ```groovy
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {
@@ -172,7 +172,7 @@ The [`examples/quantms/nextflow.config`](https://github.com/laminlabs/nf-lamin/b
 
 ```groovy
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {

--- a/examples/fetchngs/nextflow.config
+++ b/examples/fetchngs/nextflow.config
@@ -10,7 +10,7 @@
  */
 
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {

--- a/examples/fetchngs/nextflow.config
+++ b/examples/fetchngs/nextflow.config
@@ -32,7 +32,7 @@ lamin {
 
   output_artifacts {
     enabled = true
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
     exclude_pattern = '.*'   // only track files matching a rule below
 
     rules {

--- a/examples/quantms/nextflow.config
+++ b/examples/quantms/nextflow.config
@@ -44,7 +44,7 @@ lamin {
     enabled = true
 
     // Derive artifact keys by stripping the output directory from the file path.
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
 
     // Exclude everything by default; only files matching an include rule are tracked.
     exclude_pattern = '.*'

--- a/examples/quantms/nextflow.config
+++ b/examples/quantms/nextflow.config
@@ -11,7 +11,7 @@
  */
 
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {

--- a/examples/rnaseq/nextflow.config
+++ b/examples/rnaseq/nextflow.config
@@ -61,7 +61,7 @@ lamin {
     enabled = true
 
     // Derive artifact keys by stripping the output directory from the file path.
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
 
     // Exclude everything by default; only files matching an include rule are tracked.
     exclude_pattern = '.*'

--- a/examples/rnaseq/nextflow.config
+++ b/examples/rnaseq/nextflow.config
@@ -11,7 +11,7 @@
  */
 
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {

--- a/examples/scrnaseq/nextflow.config
+++ b/examples/scrnaseq/nextflow.config
@@ -62,7 +62,7 @@ lamin {
     enabled = true
 
     // Derive artifact keys by stripping the output directory from the file path.
-    key = [relativize: params.outdir]
+    key = [relativize: { params.outdir }]
 
     // Exclude everything by default; only files matching an include rule are tracked.
     exclude_pattern = '.*'

--- a/examples/scrnaseq/nextflow.config
+++ b/examples/scrnaseq/nextflow.config
@@ -12,7 +12,7 @@
  */
 
 plugins {
-  id 'nf-lamin@0.6.1'
+  id 'nf-lamin@0.6.2'
 }
 
 lamin {

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -598,10 +598,10 @@ final class LaminRunManager {
 
         // Collect paths from all relevant artifact configs
         List<Map<String, Object>> pathEntries = []
+        Map workflowParams = session.getParams() ?: [:]
 
         ArtifactConfig ac = resolveArtifactConfig(direction)
         if (ac != null) {
-            Map workflowParams = session.getParams() ?: [:]
             pathEntries.addAll(ac.collectPaths(direction, workflowParams))
         }
 
@@ -622,7 +622,7 @@ final class LaminRunManager {
 
                 // Resolve the key now that we have the actual Path object
                 if (prebuiltEvaluation != null && prebuiltEvaluation.key == null && keyConfig != null) {
-                    String resolvedKey = KeyResolver.resolveKey(keyConfig, resolvedPath)
+                    String resolvedKey = KeyResolver.resolveKey(keyConfig, resolvedPath, workflowParams)
                     prebuiltEvaluation = new ArtifactEvaluation(
                         prebuiltEvaluation.shouldTrack,
                         prebuiltEvaluation.ulabelUids,
@@ -669,7 +669,7 @@ final class LaminRunManager {
         }
 
         // Evaluate the path against the config
-        ArtifactEvaluation evaluation = artifactConfig.evaluate(path, direction)
+        ArtifactEvaluation evaluation = artifactConfig.evaluate(path, direction, session.getParams() ?: [:])
         if (evaluation.shouldTrack) {
             log.debug "Artifact '${path.toUri()}' will be tracked as ${direction} with evaluation: ${evaluation}"
         } else {

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -356,6 +356,8 @@ final class LaminRunManager {
                 } else {
                     log.warn "Could not resolve space '${config.spaceUid}'"
                 }
+            } catch (IllegalStateException e) {
+                throw e
             } catch (Exception e) {
                 log.error "Failed to resolve space '${config.spaceUid}': ${e.getMessage()}"
             }
@@ -371,6 +373,8 @@ final class LaminRunManager {
                 } else {
                     log.warn "Could not resolve branch '${config.branchUid}'"
                 }
+            } catch (IllegalStateException e) {
+                throw e
             } catch (Exception e) {
                 log.error "Failed to resolve branch '${config.branchUid}': ${e.getMessage()}"
             }
@@ -499,6 +503,7 @@ final class LaminRunManager {
             ] as Map<String, Object>
             updateRun(dummyRunRecord)
             log.info "Dry-run mode: created dummy run ${dummyRunRecord.get('uid')}"
+            return dummyRunRecord
         }
 
         WorkflowMetadata wfMetadata = session.getWorkflowMetadata()
@@ -828,7 +833,7 @@ final class LaminRunManager {
             )
             log.debug "Linked artifact ${artifactUid} as input to run ${run.get('uid')}"
         } catch (Exception e) {
-            log.debug "Could not link artifact ${artifactUid} to run: ${e.getMessage()}"
+            log.warn "Could not link artifact ${artifactUid} to run: ${e.getMessage()}"
         }
     }
 
@@ -882,7 +887,7 @@ final class LaminRunManager {
                 )
                 log.debug "Linked artifact ${artifactUid} to project ${projectUid}"
             } catch (Exception e) {
-                log.debug "Could not link artifact ${artifactUid} to project ${projectUid}: ${e.getMessage()}"
+                log.warn "Could not link artifact ${artifactUid} to project ${projectUid}: ${e.getMessage()}"
             }
         }
     }
@@ -937,7 +942,7 @@ final class LaminRunManager {
                 )
                 log.debug "Linked artifact ${artifactUid} to ulabel ${ulabelUid}"
             } catch (Exception e) {
-                log.debug "Could not link artifact ${artifactUid} to ulabel ${ulabelUid}: ${e.getMessage()}"
+                log.warn "Could not link artifact ${artifactUid} to ulabel ${ulabelUid}: ${e.getMessage()}"
             }
         }
     }
@@ -1132,7 +1137,7 @@ final class LaminRunManager {
                 )
                 log.debug "Linked transform ${transformUid} to project ${projectUid}"
             } catch (Exception e) {
-                log.debug "Could not link transform ${transformUid} to project ${projectUid}: ${e.getMessage()}"
+                log.warn "Could not link transform ${transformUid} to project ${projectUid}: ${e.getMessage()}"
             }
         }
     }
@@ -1187,7 +1192,7 @@ final class LaminRunManager {
                 )
                 log.debug "Linked transform ${transformUid} to ulabel ${ulabelUid}"
             } catch (Exception e) {
-                log.debug "Could not link transform ${transformUid} to ulabel ${ulabelUid}: ${e.getMessage()}"
+                log.warn "Could not link transform ${transformUid} to ulabel ${ulabelUid}: ${e.getMessage()}"
             }
         }
     }
@@ -1242,7 +1247,7 @@ final class LaminRunManager {
                 )
                 log.debug "Linked run ${runUid} to project ${projectUid}"
             } catch (Exception e) {
-                log.debug "Could not link run ${runUid} to project ${projectUid}: ${e.getMessage()}"
+                log.warn "Could not link run ${runUid} to project ${projectUid}: ${e.getMessage()}"
             }
         }
     }
@@ -1297,7 +1302,7 @@ final class LaminRunManager {
                 )
                 log.debug "Linked run ${runUid} to ulabel ${ulabelUid}"
             } catch (Exception e) {
-                log.debug "Could not link run ${runUid} to ulabel ${ulabelUid}: ${e.getMessage()}"
+                log.warn "Could not link run ${runUid} to ulabel ${ulabelUid}: ${e.getMessage()}"
             }
         }
     }

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
@@ -246,9 +246,11 @@ class ArtifactConfig {
      *
      * @param path The Path object for the artifact file
      * @param artifactDirection 'input' or 'output'
+     * @param workflowParams Nextflow workflow params used when the key config contains a
+     *        params-dependent closure (e.g. {@code [relativize: { params.outdir }]})
      * @return ArtifactEvaluation with shouldTrack flag and metadata map
      */
-    ArtifactEvaluation evaluate(Path path, String artifactDirection) {
+    ArtifactEvaluation evaluate(Path path, String artifactDirection, Map workflowParams = [:]) {
         String pathStr = path.toUri().toString()
 
         // Early exit if disabled or direction doesn't match
@@ -312,7 +314,7 @@ class ArtifactConfig {
         }
         String resolvedKey = null
         if (effectiveKeyConfig != null) {
-            resolvedKey = KeyResolver.resolveKey(effectiveKeyConfig, path)
+            resolvedKey = KeyResolver.resolveKey(effectiveKeyConfig, path, workflowParams)
         }
 
         return new ArtifactEvaluation(
@@ -400,9 +402,7 @@ class ArtifactConfig {
      */
     private List<String> resolveConfigPaths(Map workflowParams) {
         if (pathsClosure != null) {
-            pathsClosure.delegate = [params: workflowParams]
-            pathsClosure.resolveStrategy = Closure.DELEGATE_FIRST
-            return ConfigUtils.parseStringOrList(pathsClosure.call())
+            return ConfigUtils.parseStringOrList(ConfigUtils.evalClosureWithParams(pathsClosure, workflowParams))
         }
         return include_paths
     }

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
@@ -206,7 +206,7 @@ class ArtifactConfig {
             String name = key as String
             def ruleOpts = value
             if (ruleOpts instanceof Map) {
-                Map ruleMap = ruleOpts as Map
+                Map ruleMap = new LinkedHashMap(ruleOpts as Map)
                 // Set direction from parent config if not specified in rule
                 if (!ruleMap.containsKey('direction')) {
                     ruleMap.direction = direction

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactRule.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactRule.groovy
@@ -215,9 +215,7 @@ class ArtifactRule {
      */
     List<String> resolvePaths(Map workflowParams) {
         if (pathsClosure != null) {
-            pathsClosure.delegate = [params: workflowParams]
-            pathsClosure.resolveStrategy = Closure.DELEGATE_FIRST
-            return ConfigUtils.parseStringOrList(pathsClosure.call())
+            return ConfigUtils.parseStringOrList(ConfigUtils.evalClosureWithParams(pathsClosure, workflowParams))
         }
         return include_paths
     }

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ConfigUtils.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ConfigUtils.groovy
@@ -46,6 +46,22 @@ class ConfigUtils {
     }
 
     /**
+     * Invoke a closure whose body may reference {@code params} (e.g. {@code { params.outdir }}).
+     * Sets the closure delegate to {@code [params: workflowParams]} with DELEGATE_FIRST
+     * resolution so that bare {@code params} references resolve correctly, matching how
+     * Nextflow evaluates closures in config files.
+     *
+     * @param closure The closure to invoke
+     * @param workflowParams Nextflow workflow params (session.params)
+     * @return The value returned by the closure
+     */
+    static Object evalClosureWithParams(Closure closure, Map workflowParams) {
+        closure.delegate = [params: workflowParams ?: [:]]
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        return closure.call()
+    }
+
+    /**
      * Compile a regex pattern string into a Pattern object.
      * @param pattern The pattern string to compile (may be null)
      * @param fieldName The field name for error messages

--- a/src/main/groovy/ai/lamin/nf_lamin/config/KeyResolver.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/KeyResolver.groovy
@@ -59,9 +59,11 @@ class KeyResolver {
      *
      * @param keyConfig The key configuration value (String template, Closure, or Map)
      * @param path The Path object for the artifact file
+     * @param workflowParams Nextflow workflow params used when the key config contains a
+     *        params-dependent closure (e.g. {@code [relativize: { params.outdir }]})
      * @return The resolved key string, or null if keyConfig is null
      */
-    static String resolveKey(Object keyConfig, Path path) {
+    static String resolveKey(Object keyConfig, Path path, Map workflowParams = [:]) {
         if (keyConfig == null) {
             return null
         }
@@ -69,7 +71,7 @@ class KeyResolver {
         String pathStr = path.toUri().toString()
 
         if (keyConfig instanceof Map) {
-            return resolveMapConfig((Map) keyConfig, pathStr)
+            return resolveMapConfig((Map) keyConfig, pathStr, workflowParams)
         }
 
         if (keyConfig instanceof Closure) {
@@ -109,10 +111,12 @@ class KeyResolver {
      * @param pathStr The full file path as a URI string
      * @return The resolved key, or the basename on failure
      */
-    private static String resolveMapConfig(Map config, String pathStr) {
+    private static String resolveMapConfig(Map config, String pathStr, Map workflowParams) {
         Object relativizeValue = config.get('relativize')
         if (relativizeValue != null) {
-            Object resolvedValue = (relativizeValue instanceof Closure) ? ((Closure) relativizeValue).call() : relativizeValue
+            Object resolvedValue = (relativizeValue instanceof Closure)
+                ? ConfigUtils.evalClosureWithParams((Closure) relativizeValue, workflowParams)
+                : relativizeValue
             String baseDir = resolvedValue?.toString() ?: ''
             if (!baseDir) {
                 log.warn "Key map 'relativize' value is empty for path '${pathStr}', falling back to basename"

--- a/src/main/groovy/ai/lamin/nf_lamin/config/KeyResolver.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/KeyResolver.groovy
@@ -112,7 +112,8 @@ class KeyResolver {
     private static String resolveMapConfig(Map config, String pathStr) {
         Object relativizeValue = config.get('relativize')
         if (relativizeValue != null) {
-            String baseDir = relativizeValue.toString()
+            Object resolvedValue = (relativizeValue instanceof Closure) ? ((Closure) relativizeValue).call() : relativizeValue
+            String baseDir = resolvedValue?.toString() ?: ''
             if (!baseDir) {
                 log.warn "Key map 'relativize' value is empty for path '${pathStr}', falling back to basename"
                 return extractBasename(pathStr)


### PR DESCRIPTION
This should fix #141 

Depending on the context (e.g. launch environment or loaded plugins), trying to relativize output files with `key = [ relativize: params.outdir ]` might result in the following error:

> ERROR ~ Unknown config attribute `lamin.output_artifacts.params.outdir` -- check config file: ...

This PR fixes this by allowing and recommending deferring the evaluation of the params.outdir field using a closure, that is `key = [ relativize: { params.outdir } ]`.

Once this fix works, we could contact Seqera to inform why the simplified notation doesn't always work.
