### PR TITLE
♻️ Refactor artifact creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,15 +49,23 @@ jobs:
       matrix:
         include:
           - java_version: 21
+            # nextflow_version: latest-stable
+            nextflow_version: 25.10.4
             validation_args: ""
             lamin_env: prod
           - java_version: 21
+            # nextflow_version: latest-stable
+            nextflow_version: 25.10.4
             validation_args: "--artifact-uri lamin://laminlabs/lamindata/artifact/zZ3rE7ySAoGQtx3A --artifact-uid-on-current-instance cuQZhgVvDuy1GxxG"
             lamin_env: staging
           - java_version: 25
+            # nextflow_version: latest-edge
+            nextflow_version: 25.10.4
             validation_args: "-with-report"
             lamin_env: prod
           - java_version: 25
+            # nextflow_version: latest-edge
+            nextflow_version: 25.10.4
             validation_args: "-with-report --artifact-uri lamin://laminlabs/lamindata/artifact/zZ3rE7ySAoGQtx3A --artifact-uid-on-current-instance cuQZhgVvDuy1GxxG"
             lamin_env: staging
     steps:
@@ -84,7 +92,7 @@ jobs:
 
       - uses: nf-core/setup-nextflow@v2
         with:
-          version: "latest-stable"
+          version: ${{ matrix.nextflow_version }}
 
       - name: Compile
         run: make assemble

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminObserver.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminObserver.groovy
@@ -25,6 +25,7 @@ import nextflow.processor.TaskRun
 import nextflow.trace.TraceObserverV2
 import nextflow.trace.event.TaskEvent
 import nextflow.trace.event.FilePublishEvent
+import nextflow.trace.event.WorkflowOutputEvent
 
 import ai.lamin.nf_lamin.model.RunStatus
 
@@ -41,6 +42,14 @@ class LaminObserver implements TraceObserverV2 {
     private final LaminRunManager state = LaminRunManager.instance
     private volatile boolean runFinalized = false
 
+    /**
+     * Called once when the Nextflow session is created, before any process runs.
+     *
+     * Initialises the {@link LaminRunManager} with the session (which provides workflow
+     * metadata, parameters, config, and the output directory) and pre-creates the
+     * Transform and Run records in LaminDB so that a Run UID is available for the
+     * rest of the workflow.
+     */
     @Override
     void onFlowCreate(Session session) {
         log.debug "LaminObserver.onFlowCreate"
@@ -54,6 +63,13 @@ class LaminObserver implements TraceObserverV2 {
         }
     }
 
+    /**
+     * Called when the workflow execution starts (after processes and channels are set up).
+     *
+     * Marks the Run as started in LaminDB and processes any explicitly configured input
+     * artifact paths (from {@code lamin.artifacts} or {@code lamin.input_artifacts} config),
+     * creating input Artifact records and linking them to the Run.
+     */
     @Override
     void onFlowBegin() {
         log.debug "LaminObserver.onFlowBegin"
@@ -61,12 +77,70 @@ class LaminObserver implements TraceObserverV2 {
         state.processConfigPaths('input')
     }
 
+    /**
+     * Called each time a file is published to a {@code publishDir} destination.
+     *
+     * {@code event.target} is the final published path (local or cloud). {@code event.labels}
+     * are the strings declared with the {@code label} directive on the output's publish block.
+     *
+     * <p>Two cases are handled:</p>
+     * <ul>
+     *   <li><strong>Normal content file</strong>: creates an output Artifact for the target
+     *       path and links any publishDir labels as ULabels (if the
+     *       {@code features.publish_dir_labels} flag is enabled).</li>
+     *   <li><strong>Index/manifest file</strong> (written after {@code onWorkflowOutput}):
+     *       the Artifact was already created by {@link #onWorkflowOutput}; only the labels
+     *       are linked to the existing artifact.</li>
+     * </ul>
+     */
     @Override
     void onFilePublish(FilePublishEvent event) {
         log.debug "LaminObserver.onFilePublish: ${event.source} -> ${event.target}"
-        state.createOutputArtifact(event.target)
+        state.createOutputArtifactOnFilePublish(event.target, event.labels)
     }
 
+    /**
+     * Called once per named workflow output block after all its channel values have been published.
+     *
+     * {@code event.name} is the output block name (e.g. {@code 'bam_files'}). {@code event.value}
+     * is the fully published value: a single Path, a list of Paths, or a structured map.
+     * {@code event.index} is the optional manifest file path (CSV/JSON/YAML) that Nextflow
+     * writes to summarise all published records; it is non-null only when the output block
+     * contains an {@code index} directive.
+     *
+     * <p>For content files ({@code event.value}) this hook fires <em>after</em> the individual
+     * {@link #onFilePublish} calls, so the artifacts already exist in the cache and
+     * {@link LaminRunManager#createOutputArtifactOnWorkflowOutput} is a no-op for those paths.</p>
+     *
+     * <p>For index/manifest files ({@code event.index}) this hook fires <em>before</em> the
+     * corresponding {@link #onFilePublish}, so the artifact is created here with the output
+     * name in its description; the subsequent {@code onFilePublish} then attaches labels.</p>
+     */
+    @Override
+    void onWorkflowOutput(WorkflowOutputEvent event) {
+        log.debug "LaminObserver.onWorkflowOutput: ${event.name} = ${event.value}"
+        if (event.value instanceof Path) {
+            state.createOutputArtifactOnWorkflowOutput((Path) event.value, event.name)
+        } else if (event.value instanceof Collection) {
+            for (Object item : (Collection) event.value) {
+                if (item instanceof Path) {
+                    state.createOutputArtifactOnWorkflowOutput((Path) item, event.name)
+                }
+            }
+        }
+        if (event.index != null) {
+            state.createOutputArtifactOnWorkflowOutput(event.index, event.name)
+        }
+    }
+
+    /**
+     * Called each time a process task finishes successfully.
+     *
+     * Inspects the task's staged input files and creates an input Artifact record for each
+     * source path (the original file before staging). This captures which files were consumed
+     * as inputs, linking them to the Run for lineage tracking. Paths inside the Nextflow work
+     * directory and other excluded locations are filtered out by {@link LaminRunManager}.
+     */
     @Override
     void onTaskComplete(TaskEvent event) {
         TaskRun task = event.handler.task
@@ -81,12 +155,27 @@ class LaminObserver implements TraceObserverV2 {
         }
     }
 
+    /**
+     * Called when the workflow finishes successfully.
+     *
+     * Delegates to {@link #finalizeRunOnce()} which processes any explicitly configured output
+     * artifact paths and then updates the Run record in LaminDB with the finish time and
+     * {@code COMPLETED} status.
+     */
     @Override
     void onFlowComplete() {
         log.debug "LaminObserver.onFlowComplete"
         finalizeRunOnce()
     }
 
+    /**
+     * Called when the workflow terminates due to a task failure or other error.
+     *
+     * Delegates to {@link #finalizeRunOnce()} which updates the Run record in LaminDB with
+     * an {@code ERRORED} or {@code ABORTED} status. The guard in {@code finalizeRunOnce}
+     * ensures that if both {@code onFlowError} and {@code onFlowComplete} fire (which can
+     * happen on cancellation), the Run is only finalised once.
+     */
     @Override
     void onFlowError(TaskEvent event) {
         log.debug "LaminObserver.onFlowError"

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -44,6 +44,7 @@ import ai.lamin.nf_lamin.nio.LaminPath
 import ai.lamin.nf_lamin.util.TransformInfoHelper
 import ai.lamin.nf_lamin.config.ArtifactConfig
 import ai.lamin.nf_lamin.config.ArtifactEvaluation
+import ai.lamin.nf_lamin.config.ConfigUtils
 import ai.lamin.nf_lamin.config.KeyResolver
 
 /**
@@ -78,6 +79,10 @@ final class LaminRunManager {
     // Cache for resolved record lookups (key: "module/model/uidOrName", value: record map)
     private final Map<String, Map> recordResolutionCache = Collections.synchronizedMap(new LinkedHashMap<String, Map>())
 
+    // Cache of published output artifacts (key: path URI string, value: artifact map)
+    // Written by createOutputArtifact; read by createOutputArtifact(labels) and trackWorkflowOutput
+    private final Map<String, Map> publishedArtifactsByPath = Collections.synchronizedMap(new LinkedHashMap<String, Map>())
+
     private LaminRunManager() {
     }
 
@@ -97,6 +102,7 @@ final class LaminRunManager {
         resolvedBranchId = null
         instanceCache.clear()
         recordResolutionCache.clear()
+        publishedArtifactsByPath.clear()
     }
 
     /**
@@ -634,7 +640,7 @@ final class LaminRunManager {
                 if (direction == 'input') {
                     createInputArtifact(resolvedPath, prebuiltEvaluation)
                 } else {
-                    createOutputArtifact(resolvedPath, prebuiltEvaluation)
+                    createOutputArtifactFromConfigPaths(resolvedPath, prebuiltEvaluation)
                 }
             } catch (Exception e) {
                 log.warn "Failed to process configured ${direction} path '${pathStr}': ${e.message}"
@@ -738,11 +744,65 @@ final class LaminRunManager {
         return artifact
     }
 
-    Map<String, Object> createOutputArtifact(Path path) {
-        return createOutputArtifact(path, null)
+    /**
+     * Called from {@link ai.lamin.nf_lamin.LaminObserver#onFilePublish}.
+     *
+     * If the artifact was already created by {@code createOutputArtifactOnWorkflowOutput}
+     * (which fires first for index/manifest files), only the labels are linked to the
+     * existing artifact rather than creating a duplicate.
+     *
+     * @param path   The published file path ({@code FilePublishEvent.target})
+     * @param labels Labels from the publishDir {@code label} directive (may be null or empty)
+     */
+    Map<String, Object> createOutputArtifactOnFilePublish(Path path, List<String> labels) {
+        String pathKey = path.toUri().toString()
+        Map<String, Object> cachedArtifact = publishedArtifactsByPath.get(pathKey) as Map<String, Object>
+        if (cachedArtifact != null) {
+            if (labels && config?.features?.useOutputLabels != false) {
+                linkArtifactToUlabels(cachedArtifact, labels.collect { "+${it}" as String })
+            }
+            return cachedArtifact
+        }
+        return createOutputArtifact(path, null, labels, null)
     }
 
-    Map<String, Object> createOutputArtifact(Path path, ArtifactEvaluation prebuiltEvaluation) {
+    /**
+     * Called from {@link ai.lamin.nf_lamin.LaminRunManager#processConfigPaths} for paths
+     * declared explicitly in the {@code lamin.artifacts} config block.
+     *
+     * @param path       The output file path
+     * @param evaluation Pre-built evaluation carrying kind, key, ulabels, and description config
+     */
+    Map<String, Object> createOutputArtifactFromConfigPaths(Path path, ArtifactEvaluation evaluation) {
+        return createOutputArtifact(path, evaluation, null, null)
+    }
+
+    /**
+     * Called from {@link ai.lamin.nf_lamin.LaminObserver#onWorkflowOutput}.
+     *
+     * Associates a path with its named workflow output. If the artifact was already created
+     * by {@code createOutputArtifactOnFilePublish} (normal content files where
+     * {@code onFilePublish} fires first), this is a no-op. Otherwise the artifact is created now so that paths not
+     * published through a {@code publishDir} are still recorded.
+     *
+     * @param path       The published file path ({@code WorkflowOutputEvent.value} or {@code .index})
+     * @param outputName The workflow output block name ({@code WorkflowOutputEvent.name})
+     */
+    void createOutputArtifactOnWorkflowOutput(Path path, String outputName) {
+        if (run == null || laminInstance == null || config?.dryRun) {
+            return
+        }
+        String pathKey = path.toUri().toString()
+        if (!publishedArtifactsByPath.containsKey(pathKey)) {
+            // Path was not captured via onFilePublish – create it now so it is still recorded.
+            Map<String, Object> artifact = createOutputArtifact(path, null, null, outputName)
+            if (artifact == null) {
+                log.debug "No artifact tracked for workflow output '${outputName}' at ${pathKey}"
+            }
+        }
+    }
+
+    private Map<String, Object> createOutputArtifact(Path path, ArtifactEvaluation prebuiltEvaluation, List<String> labels, String outputName) {
         if (run == null || laminInstance == null || config.dryRun) {
             return null
         }
@@ -799,6 +859,14 @@ final class LaminRunManager {
         List<String> artifactUlabelUids = mergeUidLists(config.getUlabelUids(), evaluation.ulabelUids)
         linkArtifactToProjects(artifact, artifactProjectUids)
         linkArtifactToUlabels(artifact, artifactUlabelUids)
+
+        // Link output labels as ULabels if the feature is enabled
+        if (labels && config?.features?.useOutputLabels != false) {
+            linkArtifactToUlabels(artifact, labels.collect { "+${it}" as String })
+        }
+
+        // Cache so trackWorkflowOutput can find the artifact without creating a duplicate
+        publishedArtifactsByPath.put(path.toUri().toString(), artifact)
 
         return artifact
     }

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -700,6 +700,13 @@ final class LaminRunManager {
         }
 
         String description = "Input artifact at ${path.toUri()}"
+        if (evaluation.descriptionConfig != null) {
+            Map<String, Object> descContext = [runId: null, path: path, outputName: null] as Map<String, Object>
+            String resolved = ConfigUtils.resolveDescription(evaluation.descriptionConfig, descContext)
+            if (resolved != null) {
+                description = resolved
+            }
+        }
 
         Map<String, Object> params = [
             path: path,
@@ -757,7 +764,16 @@ final class LaminRunManager {
             return null
         }
 
-        String description = "Output artifact for run ${runId}"
+        String outputStr = outputName ? " '${outputName}'" : ""
+        String defaultDescription = "Output artifact${outputStr} for run ${runId}"
+        String description = defaultDescription
+        if (evaluation.descriptionConfig != null) {
+            Map<String, Object> descContext = [runId: runId, path: path, outputName: outputName] as Map<String, Object>
+            String resolved = ConfigUtils.resolveDescription(evaluation.descriptionConfig, descContext)
+            if (resolved != null) {
+                description = resolved
+            }
+        }
 
         Map<String, Object> params = [
             path: path,

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
@@ -120,6 +120,15 @@ class ArtifactConfig {
     ''')
     final Object key
 
+    @ConfigOption(types=[String, Closure])
+    @Description('''
+        Artifact description. Can be a plain String or a Closure whose return value
+        is used as the description. The Closure receives a binding with the following
+        variables: runId (Integer), path (Path), outputName (String, may be null).
+        Example: description = { "My output '${outputName}' in run ${runId}" }
+    ''')
+    final Object description
+
     @ConfigOption
     @Description('''
         Path-specific rules for fine-grained control over artifact tracking. Each rule can match files by pattern and override tracking decisions and metadata.
@@ -168,6 +177,7 @@ class ArtifactConfig {
         this.excludePattern = safeOpts.exclude_pattern as String
         this.kind = safeOpts.kind as String
         this.key = safeOpts.key  // keep as-is: String template or Closure
+        this.description = safeOpts.description  // keep as-is: String or Closure
 
         // Parse list fields (can be String, List, or Closure)
         this.ulabelUids = ConfigUtils.parseStringOrList(safeOpts.ulabel_uids)
@@ -267,6 +277,7 @@ class ArtifactConfig {
         List<String> ulabels = new ArrayList<>(this.ulabelUids)
         String artifactKind = this.kind
         Object effectiveKeyConfig = this.key
+        Object effectiveDescriptionConfig = this.description
         boolean shouldTrack = true
 
         // Apply global exclude pattern
@@ -306,6 +317,9 @@ class ArtifactConfig {
                 if (rule.key != null) {
                     effectiveKeyConfig = rule.key
                 }
+                if (rule.description != null) {
+                    effectiveDescriptionConfig = rule.description
+                }
             }
         }
 
@@ -321,7 +335,8 @@ class ArtifactConfig {
             shouldTrack,
             ulabels.unique(),
             artifactKind,
-            resolvedKey
+            resolvedKey,
+            effectiveDescriptionConfig
         )
     }
 
@@ -356,7 +371,8 @@ class ArtifactConfig {
                         true,
                         new ArrayList<>(this.ulabelUids),
                         this.kind,
-                        null  // key resolved later from resolved Path
+                        null,  // key resolved later from resolved Path
+                        this.description
                     )
                 ] as Map<String, Object>)
             }
@@ -377,6 +393,7 @@ class ArtifactConfig {
             String effectiveKind = rule.kind ?: this.kind
 
             Object effectiveKeyConfig = rule.key != null ? rule.key : this.key
+            Object effectiveDescriptionConfig = rule.description != null ? rule.description : this.description
 
             for (String pathStr : rule.resolvePaths(workflowParams)) {
                 result.add([
@@ -386,7 +403,8 @@ class ArtifactConfig {
                         true,
                         mergedUlabels,
                         effectiveKind,
-                        null  // key resolved later from resolved Path
+                        null,  // key resolved later from resolved Path
+                        effectiveDescriptionConfig
                     )
                 ] as Map<String, Object>)
             }
@@ -420,6 +438,7 @@ class ArtifactConfig {
             "ulabelUids=${ulabelUids}, " +
             "kind='${kind}', " +
             "key='${key instanceof Closure ? '<closure>' : key}', " +
+            "description=${description instanceof Closure ? '<closure>' : description}, " +
             "include_paths=${pathsClosure != null ? '<closure>' : include_paths}, " +
             "rules=${rules.size()} rules" +
             "}"

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactEvaluation.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactEvaluation.groovy
@@ -48,18 +48,27 @@ class ArtifactEvaluation {
     final String key
 
     /**
+     * Raw description config (String or Closure), or null if not specified.
+     * Resolved at artifact-creation time via ConfigUtils.resolveDescription with context
+     * variables: runId, path, outputName.
+     */
+    final Object descriptionConfig
+
+    /**
      * Create a new ArtifactEvaluation with typed fields.
      *
      * @param shouldTrack Whether the artifact should be tracked
      * @param ulabelUids Accumulated ULabel UIDs
      * @param kind Artifact kind, or null
      * @param key Artifact key, or null
+     * @param descriptionConfig Raw description config (String or Closure), or null
      */
-    ArtifactEvaluation(boolean shouldTrack, List<String> ulabelUids, String kind, String key = null) {
+    ArtifactEvaluation(boolean shouldTrack, List<String> ulabelUids, String kind, String key = null, Object descriptionConfig = null) {
         this.shouldTrack = shouldTrack
         this.ulabelUids = ulabelUids ?: []
         this.kind = kind
         this.key = key
+        this.descriptionConfig = descriptionConfig
     }
 
     /**
@@ -79,6 +88,6 @@ class ArtifactEvaluation {
 
     @Override
     String toString() {
-        return "ArtifactEvaluation{shouldTrack=${shouldTrack}, ulabelUids=${ulabelUids}, kind=${kind}, key=${key}}"
+        return "ArtifactEvaluation{shouldTrack=${shouldTrack}, ulabelUids=${ulabelUids}, kind=${kind}, key=${key}, descriptionConfig=${descriptionConfig instanceof Closure ? '<closure>' : descriptionConfig}}"
     }
 }

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactRule.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactRule.groovy
@@ -108,6 +108,16 @@ class ArtifactRule {
     ''')
     final Object key
 
+    @ConfigOption(types=[String, Closure])
+    @Description('''
+        Artifact description. Can be a plain String or a Closure whose return value
+        is used as the description. The Closure receives a binding with the following
+        variables: runId (Integer), path (Path), outputName (String, may be null).
+        Overrides the description set on the parent ArtifactConfig.
+        Example: description = { "My output '${outputName}' in run ${runId}" }
+    ''')
+    final Object description
+
     @ConfigOption(types=[String, List, Closure])
     @Description('''
         One or more file paths to explicitly track as artifacts.
@@ -135,6 +145,7 @@ class ArtifactRule {
         this.direction = opts.containsKey('direction') ? (opts.direction as String) : 'both'
         this.kind = opts.kind as String
         this.key = opts.key  // keep as-is: String template or Closure
+        this.description = opts.description  // keep as-is: String or Closure
         this.order = opts.containsKey('order') ? (opts.order as Integer) : 100
 
         // Parse list fields (can be String, List, or Closure)
@@ -232,6 +243,7 @@ class ArtifactRule {
             "ulabelUids=${ulabelUids}, " +
             "include_paths=${pathsClosure != null ? '<closure>' : include_paths}, " +
             "key='${key instanceof Closure ? '<closure>' : key}', " +
+            "description=${description instanceof Closure ? '<closure>' : description}, " +
             "order=${order}" +
             "}"
     }

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ConfigUtils.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ConfigUtils.groovy
@@ -62,6 +62,32 @@ class ConfigUtils {
     }
 
     /**
+     * Resolve a description from a config value (String or Closure) with a context map.
+     *
+     * The Closure receives a binding with the provided context variables
+     * (e.g. {@code runId}, {@code path}, {@code outputName}) via
+     * {@code DELEGATE_FIRST} resolution, matching how Nextflow evaluates closures.
+     * Additional context variables may be added in the future without breaking existing closures.
+     *
+     * @param descConfig The description config value (String, Closure, or null)
+     * @param context Map of context variables exposed to the closure
+     * @return The resolved description string, or null if descConfig is null
+     */
+    static String resolveDescription(Object descConfig, Map<String, Object> context) {
+        if (descConfig == null) {
+            return null
+        }
+        if (descConfig instanceof Closure) {
+            Closure cl = (Closure) descConfig
+            cl.delegate = context
+            cl.resolveStrategy = Closure.DELEGATE_FIRST
+            Object result = cl.call()
+            return result?.toString()
+        }
+        return descConfig.toString()
+    }
+
+    /**
      * Compile a regex pattern string into a Pattern object.
      * @param pattern The pattern string to compile (may be null)
      * @param fieldName The field name for error messages

--- a/src/main/groovy/ai/lamin/nf_lamin/config/FeaturesConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/FeaturesConfig.groovy
@@ -47,26 +47,40 @@ class FeaturesConfig {
     ''')
     final Boolean manageS3Credentials
 
+    @ConfigOption
+    @Description('''
+        Enable linking of publishDir labels to artifacts as ULabels.
+        When enabled (default: true), labels attached to publishDir directives
+        (via `publishDir label:`) are automatically created as ULabels in LaminDB
+        and linked to the corresponding artifact. Disable this if you do not want
+        publishDir labels to be stored in LaminDB.
+    ''')
+    final Boolean useOutputLabels
+
     /**
      * Default constructor
      */
     FeaturesConfig() {
         this.manageS3Credentials = true
+        this.useOutputLabels = true
     }
 
     /**
      * Create a FeaturesConfig from a configuration map.
      *
-     * @param opts Configuration map with keys: manage_s3_credentials
+     * @param opts Configuration map with keys: manage_s3_credentials, publish_dir_labels
      */
     FeaturesConfig(Map opts) {
         this.manageS3Credentials = opts?.containsKey('manage_s3_credentials')
             ? (opts.manage_s3_credentials as Boolean)
             : true
+        this.useOutputLabels = opts?.containsKey('use_output_labels')
+            ? (opts.use_output_labels as Boolean)
+            : true
     }
 
     @Override
     String toString() {
-        return "FeaturesConfig{manageS3Credentials=${manageS3Credentials}}"
+        return "FeaturesConfig{manageS3Credentials=${manageS3Credentials}, useOutputLabels=${useOutputLabels}}"
     }
 }


### PR DESCRIPTION
* Added onWorkflowOutput support to track named workflow output paths and their index/manifest files as artifacts, correctly handling the ordering difference where content files have their artifact created by onFilePublish first while index files are created by onWorkflowOutput first.
* Added a features.use_output_labels flag to control whether publishDir labels are linked to artifacts as ULabels.
* Added a description option to ArtifactRule and ArtifactConfig that accepts a plain string or a Groovy closure (with runId, path, outputName in scope) to customise the artifact description.