### PR TITLE
:sparkles: Allow annotating artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,11 +230,14 @@ lamin {
 ### DSL Extension Functions
 
 ```groovy
-include { getRunUid; getTransformUid; getInstanceSlug } from 'plugin/nf-lamin'
+include { getRunUid; getTransformUid; getInstanceSlug; annotateArtifact } from 'plugin/nf-lamin'
 
 def runUid = getRunUid()                                    // Current run UID
 def transformUid = getTransformUid()                        // Current transform UID
 def slug = getInstanceSlug()                                // "org/instance"
+
+// Attach metadata to the artifact of a published file; returns the file unchanged
+ch | map { f -> annotateArtifact(f, kind: 'dataset', ulabel_uids: ['+qc-passed']) }
 
 // Use lamin:// URI to resolve artifact paths
 def path = file('lamin://org/instance/artifact/uid16chars1234')

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,18 @@ install:
 release:
 	./gradlew releasePlugin
 
+# Where the validation workflows publish to. Set to a remote bucket (e.g.
+# OUTDIR=$LAMIN_TEST_BUCKET/validation/$(date +%s)) to exercise artifact tracking,
+# which only happens for remote paths.
+OUTDIR ?= results
+
 # Run all validation workflows
-# Usage: make validate [BRANCH=branch-name] [VERSION=x.y.z] [ARGS="extra args"]
+# Usage: make validate [BRANCH=branch-name] [VERSION=x.y.z] [OUTDIR=s3://...] [ARGS="extra args"]
 validate: validate-legacy validate-run
 
 # Run the legacy validation workflow (Nextflow < 26.04, legacy DSL2 syntax parser)
 # Uses publishDir directive; output directory is set via --output-dir param.
-# Usage: make validate-legacy [BRANCH=branch-name] [VERSION=x.y.z] [ARGS="extra args"]
+# Usage: make validate-legacy [BRANCH=branch-name] [VERSION=x.y.z] [OUTDIR=s3://...] [ARGS="extra args"]
 validate-legacy:
 	BRANCH=$${BRANCH:-$$(git symbolic-ref --short HEAD 2>/dev/null || echo "main")}; \
 	VERSION=$${VERSION:-$$(awk -F"'" '/^version =/{print $$2}' build.gradle)}; \
@@ -38,13 +43,13 @@ validate-legacy:
 		-main-script validation/legacy_syntax_parser/main.nf \
 		-config configs/ci.config \
 		-plugins "nf-lamin@$$VERSION" \
-		--output-dir results \
+		--output-dir $(OUTDIR) \
 		$(ARGS)
 
 # Run the validation workflow using Nextflow 26.04+ features
 # Uses typed params/processes/workflows and the workflow output block.
 # Output directory is set via the -output-dir CLI option.
-# Usage: make validate-run [BRANCH=branch-name] [VERSION=x.y.z] [ARGS="extra args"]
+# Usage: make validate-run [BRANCH=branch-name] [VERSION=x.y.z] [OUTDIR=s3://...] [ARGS="extra args"]
 validate-run:
 	BRANCH=$${BRANCH:-$$(git symbolic-ref --short HEAD 2>/dev/null || echo "main")}; \
 	VERSION=$${VERSION:-$$(awk -F"'" '/^version =/{print $$2}' build.gradle)}; \
@@ -56,5 +61,5 @@ validate-run:
 		-main-script validation/run/main.nf \
 		-config configs/ci.config \
 		-plugins "nf-lamin@$$VERSION" \
-		-output-dir results \
+		-output-dir $(OUTDIR) \
 		$(ARGS)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -51,4 +51,55 @@ workflow {
 }
 ```
 
+## `annotateArtifact()`
+
+Attaches metadata to the artifact that Lamin registers for a file.
+
+The file keeps being published by Nextflow as usual — `publishDir` and workflow outputs are untouched. This function only records what should be attached to the resulting artifact, which lets a workflow decide its metadata programmatically instead of only through static config.
+
+**Parameters:**
+
+| Name           | Type          | Description                                    |
+| -------------- | ------------- | ---------------------------------------------- |
+| _(positional)_ | Path/String   | The file to annotate, or a collection of files |
+| `kind`         | String        | Artifact kind: `dataset`, `model`, or `plan`   |
+| `description`  | String        | Artifact description                           |
+| `ulabel_uids`  | List\<String> | ULabel UIDs or named references to link        |
+| `project_uids` | List\<String> | Project UIDs or named references to link       |
+
+Like the [UID fields in the config](config.md#core-settings), `ulabel_uids` and `project_uids` accept a UID, or a named reference: `'?name'` (look up, omit if missing), `'!name'` (look up, error if missing), `'+name'` (create if missing).
+
+**Returns:** the file it was given, unchanged, so the call can be the body of a `map` closure.
+
+**Example:**
+
+```groovy
+include { annotateArtifact } from 'plugin/nf-lamin'
+
+workflow {
+  ALIGN(ch_reads)
+    | map { meta, bam ->
+        annotateArtifact(bam,
+          kind: 'dataset',
+          description: "Aligned reads for sample ${meta.id}",
+          ulabel_uids: ['+alignment', meta.qc_passed ? '+qc-passed' : '+qc-failed']
+        )
+        [meta, bam]
+      }
+    | set { ch_bam }
+
+  publish:
+  bam = ch_bam
+}
+```
+
+**Notes:**
+
+- It can be called before or after the file is published — the annotation is applied whenever the artifact is registered.
+- Repeated calls for the same file accumulate.
+- It does nothing when no Lamin instance is configured, so a workflow using it still runs without the plugin being connected.
+- A file that is annotated but never tracked as an artifact is reported in a warning at the end of the run.
+
+---
+
 All functions return `null` if the plugin hasn't initialized the run yet, so they are best used in the workflow body (not in process definitions).

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -1,56 +1,5 @@
 # Functions
 
-## `getRunUid()`
-
-Returns the UID of the current Lamin run.
-
-**Returns:** `String` - The run UID, or `null` if the plugin hasn't initialized the run yet.
-
-**Example:**
-
-```groovy
-include { getRunUid } from 'plugin/nf-lamin'
-
-workflow {
-  def runUid = getRunUid()
-  log.info "Current run: ${runUid}"
-}
-```
-
-## `getTransformUid()`
-
-Returns the UID of the current Lamin transform.
-
-**Returns:** `String` - The transform UID, or `null` if the plugin hasn't initialized the transform yet.
-
-**Example:**
-
-```groovy
-include { getTransformUid } from 'plugin/nf-lamin'
-
-workflow {
-  def transformUid = getTransformUid()
-  log.info "Current transform: ${transformUid}"
-}
-```
-
-## `getInstanceSlug()`
-
-Returns the currently configured LaminDB instance identifier.
-
-**Returns:** `String` - The instance slug in the format "owner/name" (e.g., "laminlabs/lamindata"), or `null` if not available.
-
-**Example:**
-
-```groovy
-include { getInstanceSlug } from 'plugin/nf-lamin'
-
-workflow {
-  def instance = getInstanceSlug()
-  log.info "Connected to LaminDB instance: ${instance}"
-}
-```
-
 ## `annotateArtifact()`
 
 Attaches metadata to the artifact that Lamin registers for a file.
@@ -100,6 +49,57 @@ workflow {
 - It does nothing when no Lamin instance is configured, so a workflow using it still runs without the plugin being connected.
 - A file that is annotated but never tracked as an artifact is reported in a warning at the end of the run.
 
+## `getInstanceSlug()`
+
+Returns the currently configured LaminDB instance identifier.
+
+**Returns:** `String` - The instance slug in the format "owner/name" (e.g., "laminlabs/lamindata"), or `null` if not available.
+
+**Example:**
+
+```groovy
+include { getInstanceSlug } from 'plugin/nf-lamin'
+
+workflow {
+  def instance = getInstanceSlug()
+  log.info "Connected to LaminDB instance: ${instance}"
+}
+```
+
+## `getRunUid()`
+
+Returns the UID of the current Lamin run.
+
+**Returns:** `String` - The run UID, or `null` if the plugin hasn't initialized the run yet.
+
+**Example:**
+
+```groovy
+include { getRunUid } from 'plugin/nf-lamin'
+
+workflow {
+  def runUid = getRunUid()
+  log.info "Current run: ${runUid}"
+}
+```
+
+## `getTransformUid()`
+
+Returns the UID of the current Lamin transform.
+
+**Returns:** `String` - The transform UID, or `null` if the plugin hasn't initialized the transform yet.
+
+**Example:**
+
+```groovy
+include { getTransformUid } from 'plugin/nf-lamin'
+
+workflow {
+  def transformUid = getTransformUid()
+  log.info "Current transform: ${transformUid}"
+}
+```
+
 ---
 
-All functions return `null` if the plugin hasn't initialized the run yet, so they are best used in the workflow body (not in process definitions).
+The `get*()` functions return `null` if the plugin hasn't initialized the run yet, so they are best used in the workflow body (not in process definitions).

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -62,7 +62,7 @@ This function records what should be attached to the resulting artifact, which l
 | Name           | Type          | Description                                    |
 | -------------- | ------------- | ---------------------------------------------- |
 | _(positional)_ | Path/String   | The file to annotate, or a collection of files |
-| `kind`         | String        | Artifact kind: `dataset`, `model`, or `plan`   |
+| `kind`         | String        | Artifact kind, e.g. `dataset`, `model`, `plan` |
 | `description`  | String        | Artifact description                           |
 | `ulabel_uids`  | List\<String> | ULabel UIDs or named references to link        |
 | `project_uids` | List\<String> | Project UIDs or named references to link       |

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -55,7 +55,7 @@ workflow {
 
 Attaches metadata to the artifact that Lamin registers for a file.
 
-The file keeps being published by Nextflow as usual — `publishDir` and workflow outputs are untouched. This function only records what should be attached to the resulting artifact, which lets a workflow decide its metadata programmatically instead of only through static config.
+This function records what should be attached to the resulting artifact, which lets a workflow decide its metadata programmatically instead of only through static config.
 
 **Parameters:**
 
@@ -95,7 +95,7 @@ workflow {
 
 **Notes:**
 
-- It can be called before or after the file is published — the annotation is applied whenever the artifact is registered.
+- It can be called before or after the file is published. The annotation is applied whenever the artifact is registered.
 - Repeated calls for the same file accumulate.
 - It does nothing when no Lamin instance is configured, so a workflow using it still runs without the plugin being connected.
 - A file that is annotated but never tracked as an artifact is reported in a warning at the end of the run.

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminExtension.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminExtension.groovy
@@ -19,12 +19,14 @@ package ai.lamin.nf_lamin
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
+import nextflow.file.FileHelper
 import nextflow.plugin.extension.Function
 import nextflow.plugin.extension.PluginExtensionPoint
 import java.nio.file.Path
 import ai.lamin.nf_lamin.hub.LaminHub
 import ai.lamin.nf_lamin.instance.Instance
 import ai.lamin.nf_lamin.hub.InstanceSettings
+import ai.lamin.nf_lamin.model.ArtifactAnnotation
 
 /**
  * Implements a custom function which can be imported by
@@ -71,6 +73,75 @@ class LaminExtension extends PluginExtensionPoint {
     @Function
     String getInstanceSlug() {
         return LaminRunManager.instance.getInstanceSlug()
+    }
+
+    /**
+     * Attaches metadata to the artifact that Lamin registers for a file.
+     *
+     * The file keeps being published by Nextflow as usual; this only records what should be
+     * attached to the resulting artifact. It can therefore be called before or after the file
+     * is published, and repeated calls for the same file accumulate.
+     *
+     * <pre>
+     * ch_out | map { f -&gt; annotateArtifact(f, kind: 'dataset', ulabel_uids: ['+qc-passed']) }
+     * </pre>
+     *
+     * Does nothing when no Lamin instance is configured, so a workflow using it still runs
+     * without the plugin being connected.
+     *
+     * @param opts   Named arguments: {@code kind}, {@code description}, {@code ulabel_uids},
+     *               {@code project_uids}
+     * @param target A file, a file path as a String, or a collection of either
+     * @return {@code target}, unchanged, so the call can be the body of a {@code map} closure
+     * @throws IllegalArgumentException if an option or the target type is not supported
+     */
+    @Function
+    Object annotateArtifact(Map opts, Object target) {
+        ArtifactAnnotation annotation = ArtifactAnnotation.fromMap(opts)
+        for (Path path : toPaths(target)) {
+            LaminRunManager.instance.registerAnnotation(path, annotation)
+        }
+        return target
+    }
+
+    /**
+     * Attaches metadata to the artifact of a file, without any named arguments.
+     *
+     * @see #annotateArtifact(Map, Object)
+     */
+    @Function
+    Object annotateArtifact(Object target) {
+        return annotateArtifact([:], target)
+    }
+
+    /**
+     * Resolve the target of {@code annotateArtifact} to the paths it refers to.
+     *
+     * @param target A Path, a path String, or a collection of either
+     * @return the resolved paths
+     * @throws IllegalArgumentException if the target is null or of an unsupported type
+     */
+    private static List<Path> toPaths(Object target) {
+        if (target == null) {
+            throw new IllegalArgumentException('annotateArtifact: no file to annotate (target is null)')
+        }
+        if (target instanceof Path) {
+            return [(Path) target]
+        }
+        if (target instanceof CharSequence) {
+            return [FileHelper.asPath(target.toString())]
+        }
+        if (target instanceof Collection) {
+            List<Path> paths = []
+            for (Object item : (Collection) target) {
+                paths.addAll(toPaths(item))
+            }
+            return paths
+        }
+        throw new IllegalArgumentException(
+            "annotateArtifact: cannot annotate a ${target.getClass().simpleName}, " +
+            'expected a file, a file path, or a collection of either'
+        )
     }
 
 }

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminExtension.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminExtension.groovy
@@ -19,7 +19,6 @@ package ai.lamin.nf_lamin
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
-import nextflow.file.FileHelper
 import nextflow.plugin.extension.Function
 import nextflow.plugin.extension.PluginExtensionPoint
 import java.nio.file.Path
@@ -27,6 +26,7 @@ import ai.lamin.nf_lamin.hub.LaminHub
 import ai.lamin.nf_lamin.instance.Instance
 import ai.lamin.nf_lamin.hub.InstanceSettings
 import ai.lamin.nf_lamin.model.ArtifactAnnotation
+import ai.lamin.nf_lamin.util.PathUtils
 
 /**
  * Implements a custom function which can be imported by
@@ -98,7 +98,7 @@ class LaminExtension extends PluginExtensionPoint {
     @Function
     Object annotateArtifact(Map opts, Object target) {
         ArtifactAnnotation annotation = ArtifactAnnotation.fromMap(opts)
-        for (Path path : toPaths(target)) {
+        for (Path path : PathUtils.toPaths(target, 'annotateArtifact')) {
             LaminRunManager.instance.registerAnnotation(path, annotation)
         }
         return target
@@ -112,36 +112,6 @@ class LaminExtension extends PluginExtensionPoint {
     @Function
     Object annotateArtifact(Object target) {
         return annotateArtifact([:], target)
-    }
-
-    /**
-     * Resolve the target of {@code annotateArtifact} to the paths it refers to.
-     *
-     * @param target A Path, a path String, or a collection of either
-     * @return the resolved paths
-     * @throws IllegalArgumentException if the target is null or of an unsupported type
-     */
-    private static List<Path> toPaths(Object target) {
-        if (target == null) {
-            throw new IllegalArgumentException('annotateArtifact: no file to annotate (target is null)')
-        }
-        if (target instanceof Path) {
-            return [(Path) target]
-        }
-        if (target instanceof CharSequence) {
-            return [FileHelper.asPath(target.toString())]
-        }
-        if (target instanceof Collection) {
-            List<Path> paths = []
-            for (Object item : (Collection) target) {
-                paths.addAll(toPaths(item))
-            }
-            return paths
-        }
-        throw new IllegalArgumentException(
-            "annotateArtifact: cannot annotate a ${target.getClass().simpleName}, " +
-            'expected a file, a file path, or a collection of either'
-        )
     }
 
 }

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminObserver.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminObserver.groovy
@@ -93,6 +93,8 @@ class LaminObserver implements TraceObserverV2 {
     /**
      * Called each time a file is published to a {@code publishDir} destination.
      *
+     * {@code event.source} is the path the file was published from - the same path the workflow
+     * holds in its channels, and therefore the one {@code annotateArtifact()} keys on.
      * {@code event.target} is the final published path (local or cloud). {@code event.labels}
      * are the strings declared with the {@code label} directive on the output's publish block.
      *
@@ -110,7 +112,7 @@ class LaminObserver implements TraceObserverV2 {
     void onFilePublish(FilePublishEvent event) {
         log.debug "LaminObserver.onFilePublish: ${event.source} -> ${event.target}"
         if (!trackingEnabled) return
-        state.createOutputArtifactOnFilePublishAsync(event.target, event.labels)
+        state.createOutputArtifactOnFilePublishAsync(event.source, event.target, event.labels)
     }
 
     /**
@@ -203,6 +205,7 @@ class LaminObserver implements TraceObserverV2 {
         runFinalized = true
         state.processConfigPathsAsync('output')
         state.awaitArtifactTasks()
+        state.warnUnmatchedAnnotations()
         state.finalizeRun()
     }
 }

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -46,6 +46,7 @@ import ai.lamin.nf_lamin.hub.LaminHubSettings
 import ai.lamin.nf_lamin.instance.Instance
 import ai.lamin.nf_lamin.instance.PermissionDeniedException
 import ai.lamin.nf_lamin.hub.InstanceSettings
+import ai.lamin.nf_lamin.model.ArtifactAnnotation
 import ai.lamin.nf_lamin.model.RunStatus
 import ai.lamin.nf_lamin.nio.LaminPath
 import ai.lamin.nf_lamin.util.TransformInfoHelper
@@ -93,6 +94,15 @@ final class LaminRunManager {
     // Written by createOutputArtifact; read by createOutputArtifact(labels) and trackWorkflowOutput
     private final Map<String, Map> publishedArtifactsByPath = Collections.synchronizedMap(new LinkedHashMap<String, Map>())
 
+    // Annotations requested from the workflow via annotateArtifact(), keyed by annotation key
+    private final Map<String, List<ArtifactAnnotation>> pendingAnnotations = new ConcurrentHashMap<String, List<ArtifactAnnotation>>()
+
+    // Artifacts already created, keyed by every annotation key that resolves to them
+    private final Map<String, List<Map<String, Object>>> artifactsByAnnotationKey = new ConcurrentHashMap<String, List<Map<String, Object>>>()
+
+    // Annotation keys that matched at least one artifact
+    private final Set<String> matchedAnnotationKeys = ConcurrentHashMap.newKeySet()
+
     // Tracks whether the one-time local file warning has been shown this session
     private volatile boolean localFileWarningShown = false
 
@@ -117,6 +127,9 @@ final class LaminRunManager {
         LaminConnection.getInstance().reset()
         recordResolutionCache.clear()
         publishedArtifactsByPath.clear()
+        pendingAnnotations.clear()
+        artifactsByAnnotationKey.clear()
+        matchedAnnotationKeys.clear()
         artifactExecutor = createArtifactExecutor(ApiConfig.DEFAULT_MAX_WORKERS)
     }
 
@@ -685,10 +698,10 @@ final class LaminRunManager {
         }
     }
 
-    void createOutputArtifactOnFilePublishAsync(Path target, List<String> labels) {
+    void createOutputArtifactOnFilePublishAsync(Path source, Path target, List<String> labels) {
         submitToExecutor("file-publish artifact for ${target}") {
             try {
-                createOutputArtifactOnFilePublish(target, labels)
+                createOutputArtifactOnFilePublish(source, target, labels)
             } catch (Exception e) {
                 logArtifactFailure("Failed to create output artifact for ${target}", e)
             }
@@ -716,6 +729,201 @@ final class LaminRunManager {
                 logArtifactFailure("Failed to create input artifacts for ${taskName}", e)
             }
         }
+    }
+
+    /**
+     * Record metadata to attach to the artifact of a path, as requested from a workflow via
+     * {@code annotateArtifact()}.
+     *
+     * The workflow and the publishing machinery run concurrently, so a path may be annotated
+     * either before or after its artifact exists. Both orders are handled: the annotation is
+     * remembered here and drained by {@link #recordArtifactForAnnotation}, and any artifact
+     * already registered for the path is annotated right away.
+     *
+     * @param path       The file being annotated
+     * @param annotation The metadata to attach
+     */
+    void registerAnnotation(Path path, ArtifactAnnotation annotation) {
+        if (path == null || annotation == null || annotation.isEmpty()) {
+            log.debug "Ignoring empty annotation for ${path}"
+            return
+        }
+        if (laminInstance == null) {
+            log.debug "No Lamin instance configured; ignoring annotation for ${path}"
+            return
+        }
+        if (config?.dryRun) {
+            log.info "Dry-run mode: would annotate ${path.toUri()} with ${annotation}"
+            return
+        }
+
+        String key = annotationKey(path)
+        if (key == null) {
+            return
+        }
+        log.debug "Registering annotation for ${key}: ${annotation}"
+
+        pendingAnnotations
+            .computeIfAbsent(key, { Collections.synchronizedList(new ArrayList<ArtifactAnnotation>()) })
+            .add(annotation)
+
+        List<Map<String, Object>> artifacts = artifactsByAnnotationKey.get(key)
+        if (artifacts == null) {
+            return
+        }
+        // The artifact already exists, so apply straight away - on a worker thread, since this
+        // runs on a dataflow operator thread that must not block on API calls
+        matchedAnnotationKeys.add(key)
+        List<Map<String, Object>> snapshot
+        synchronized (artifacts) {
+            snapshot = new ArrayList<Map<String, Object>>(artifacts)
+        }
+        for (Map<String, Object> artifact : snapshot) {
+            submitToExecutor("annotation for ${key}") {
+                try {
+                    applyAnnotation(artifact, annotation)
+                } catch (Exception e) {
+                    logArtifactFailure("Failed to annotate artifact ${artifact.get('uid')}", e)
+                }
+            }
+        }
+    }
+
+    /**
+     * Register an artifact under the paths that may have been annotated for it, and apply any
+     * annotation already requested for those paths.
+     *
+     * Runs on the artifact executor (the callers create artifacts there), so annotations are
+     * applied inline rather than submitted again.
+     *
+     * @param artifact The artifact map (must contain 'id' and 'uid')
+     * @param paths    Paths that resolve to this artifact; nulls are ignored
+     */
+    private void recordArtifactForAnnotation(Map<String, Object> artifact, Path... paths) {
+        if (artifact == null || paths == null) {
+            return
+        }
+        for (Path path : paths) {
+            String key = annotationKey(path)
+            if (key == null) {
+                continue
+            }
+            artifactsByAnnotationKey
+                .computeIfAbsent(key, { Collections.synchronizedList(new ArrayList<Map<String, Object>>()) })
+                .add(artifact)
+
+            List<ArtifactAnnotation> annotations = pendingAnnotations.get(key)
+            if (annotations == null) {
+                continue
+            }
+            matchedAnnotationKeys.add(key)
+            List<ArtifactAnnotation> snapshot
+            synchronized (annotations) {
+                snapshot = new ArrayList<ArtifactAnnotation>(annotations)
+            }
+            for (ArtifactAnnotation annotation : snapshot) {
+                try {
+                    applyAnnotation(artifact, annotation)
+                } catch (Exception e) {
+                    logArtifactFailure("Failed to annotate artifact ${artifact.get('uid')}", e)
+                }
+            }
+        }
+    }
+
+    /**
+     * Attach an annotation's metadata to an artifact.
+     *
+     * Every operation is an idempotent PATCH or upsert, so re-applying an annotation - which
+     * happens when a path is annotated both before and after its artifact was created - is
+     * harmless.
+     *
+     * @param artifact   The artifact map (must contain 'id' and 'uid')
+     * @param annotation The metadata to attach
+     */
+    private void applyAnnotation(Map<String, Object> artifact, ArtifactAnnotation annotation) {
+        if (artifact == null || annotation == null || laminInstance == null) {
+            return
+        }
+        String artifactUid = artifact.get('uid') as String
+        if (!artifactUid) {
+            log.warn "Cannot annotate artifact without a uid: ${artifact}"
+            return
+        }
+
+        Map<String, Object> updates = [:] as Map<String, Object>
+        if (annotation.kind) {
+            updates.put('kind', annotation.kind)
+        }
+        if (annotation.description) {
+            updates.put('description', annotation.description)
+        }
+        if (updates) {
+            try {
+                laminInstance.updateRecord(
+                    moduleName: 'core',
+                    modelName: 'artifact',
+                    uid: artifactUid,
+                    data: updates
+                )
+                log.debug "Updated artifact ${artifactUid} with ${updates}"
+            } catch (Exception e) {
+                log.warn "Could not update artifact ${artifactUid} with ${updates}: ${e.getMessage()}"
+            }
+        }
+
+        linkArtifactToUlabels(artifact, annotation.ulabelUids)
+        linkArtifactToProjects(artifact, annotation.projectUids)
+    }
+
+    /**
+     * Warn about annotations that never matched an artifact, i.e. files that were annotated but
+     * never published or otherwise tracked. Called once all artifact tasks have completed.
+     */
+    void warnUnmatchedAnnotations() {
+        List<String> unmatched = pendingAnnotations.keySet().findAll { !matchedAnnotationKeys.contains(it) }.toList()
+        if (!unmatched) {
+            return
+        }
+        log.warn "annotateArtifact was called for ${unmatched.size()} path(s) that were not tracked as artifacts, " +
+            "so their annotations were not applied: ${unmatched.join(', ')}"
+    }
+
+    /**
+     * The key a path is annotated under.
+     *
+     * Absolutises and normalises the path so that the value a workflow holds (which may be
+     * relative) matches the one reported by the publish event, and renders remote protocols
+     * consistently because some providers print them as {@code s3:/} or {@code s3:///}.
+     *
+     * @param path The path to key on
+     * @return the annotation key, or null if the path is null
+     */
+    private static String annotationKey(Path path) {
+        if (path == null) {
+            return null
+        }
+        URI uri
+        try {
+            uri = path.toAbsolutePath().normalize().toUri()
+        } catch (Exception e) {
+            log.debug "Could not absolutise ${path}: ${e.message}"
+            uri = path.toUri()
+        }
+
+        String uriStr = uri.toString()
+        String scheme = uri.getScheme()
+        // Leave local paths alone: 'file' URIs have no authority, so their leading slashes
+        // are part of the path and collapsing them would mangle the key
+        if (scheme == null || scheme == 'file') {
+            return uriStr
+        }
+        String rest = uriStr.substring(scheme.length() + 1)
+        int slashes = 0
+        while (slashes < rest.length() && rest.charAt(slashes) == ('/' as char)) {
+            slashes++
+        }
+        return scheme + '://' + rest.substring(slashes)
     }
 
     /**
@@ -853,6 +1061,11 @@ final class LaminRunManager {
         linkArtifactToProjects(artifact, artifactProjectUids)
         linkArtifactToUlabels(artifact, artifactUlabelUids)
 
+        // A lamin:// input is annotated under the URI the workflow holds, but registered under
+        // the storage path it resolves to, so record both
+        Path storagePath = path instanceof LaminPath ? ((LaminPath) path).resolveToStorage() : null
+        recordArtifactForAnnotation(artifact, path, storagePath)
+
         return artifact
     }
 
@@ -863,19 +1076,23 @@ final class LaminRunManager {
      * (which fires first for index/manifest files), only the labels are linked to the
      * existing artifact rather than creating a duplicate.
      *
+     * @param source The path the file was published from ({@code FilePublishEvent.source}), which
+     *               is the path the workflow itself holds and can annotate (may be null)
      * @param path   The published file path ({@code FilePublishEvent.target})
      * @param labels Labels from the publishDir {@code label} directive (may be null or empty)
      */
-    Map<String, Object> createOutputArtifactOnFilePublish(Path path, List<String> labels) {
+    Map<String, Object> createOutputArtifactOnFilePublish(Path source, Path path, List<String> labels) {
         String pathKey = path.toUri().toString()
         Map<String, Object> cachedArtifact = publishedArtifactsByPath.get(pathKey) as Map<String, Object>
         if (cachedArtifact != null) {
             if (labels && config?.features?.use_output_labels != false) {
                 linkArtifactToUlabels(cachedArtifact, labels.collect { "+${it}" as String })
             }
+            // The source is only known here, so register it even when the artifact already exists
+            recordArtifactForAnnotation(cachedArtifact, source)
             return cachedArtifact
         }
-        return createOutputArtifact(path, null, labels, null)
+        return createOutputArtifact(path, null, labels, null, source)
     }
 
     /**
@@ -885,7 +1102,7 @@ final class LaminRunManager {
      * @param evaluation Pre-built evaluation carrying kind, key, ulabels, and description config
      */
     Map<String, Object> createOutputArtifactFromConfigPaths(Path path, ArtifactEvaluation evaluation) {
-        return createOutputArtifact(path, evaluation, null, null)
+        return createOutputArtifact(path, evaluation, null, null, null)
     }
 
     /**
@@ -906,14 +1123,14 @@ final class LaminRunManager {
         String pathKey = path.toUri().toString()
         if (!publishedArtifactsByPath.containsKey(pathKey)) {
             // Path was not captured via onFilePublish – create it now so it is still recorded.
-            Map<String, Object> artifact = createOutputArtifact(path, null, null, outputName)
+            Map<String, Object> artifact = createOutputArtifact(path, null, null, outputName, null)
             if (artifact == null) {
                 log.debug "No artifact tracked for workflow output '${outputName}' at ${pathKey}"
             }
         }
     }
 
-    private Map<String, Object> createOutputArtifact(Path path, ArtifactEvaluation prebuiltEvaluation, List<String> labels, String outputName) {
+    private Map<String, Object> createOutputArtifact(Path path, ArtifactEvaluation prebuiltEvaluation, List<String> labels, String outputName, Path source) {
         if (run == null || laminInstance == null || config.dryRun) {
             return null
         }
@@ -975,6 +1192,10 @@ final class LaminRunManager {
 
         // Cache so trackWorkflowOutput can find the artifact without creating a duplicate
         publishedArtifactsByPath.put(path.toUri().toString(), artifact)
+
+        // Apply any annotations the workflow requested for this file, under both the path it
+        // was published from (what the workflow holds) and the path it was published to
+        recordArtifactForAnnotation(artifact, source, path)
 
         return artifact
     }

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -49,6 +49,7 @@ import ai.lamin.nf_lamin.hub.InstanceSettings
 import ai.lamin.nf_lamin.model.ArtifactAnnotation
 import ai.lamin.nf_lamin.model.RunStatus
 import ai.lamin.nf_lamin.nio.LaminPath
+import ai.lamin.nf_lamin.util.PathUtils
 import ai.lamin.nf_lamin.util.TransformInfoHelper
 import ai.lamin.nf_lamin.config.ArtifactConfig
 import ai.lamin.nf_lamin.config.ArtifactEvaluation
@@ -757,7 +758,7 @@ final class LaminRunManager {
             return
         }
 
-        String key = annotationKey(path)
+        String key = PathUtils.toUriKey(path)
         if (key == null) {
             return
         }
@@ -804,7 +805,7 @@ final class LaminRunManager {
             return
         }
         for (Path path : paths) {
-            String key = annotationKey(path)
+            String key = PathUtils.toUriKey(path)
             if (key == null) {
                 continue
             }
@@ -887,43 +888,6 @@ final class LaminRunManager {
         }
         log.warn "annotateArtifact was called for ${unmatched.size()} path(s) that were not tracked as artifacts, " +
             "so their annotations were not applied: ${unmatched.join(', ')}"
-    }
-
-    /**
-     * The key a path is annotated under.
-     *
-     * Absolutises and normalises the path so that the value a workflow holds (which may be
-     * relative) matches the one reported by the publish event, and renders remote protocols
-     * consistently because some providers print them as {@code s3:/} or {@code s3:///}.
-     *
-     * @param path The path to key on
-     * @return the annotation key, or null if the path is null
-     */
-    private static String annotationKey(Path path) {
-        if (path == null) {
-            return null
-        }
-        URI uri
-        try {
-            uri = path.toAbsolutePath().normalize().toUri()
-        } catch (Exception e) {
-            log.debug "Could not absolutise ${path}: ${e.message}"
-            uri = path.toUri()
-        }
-
-        String uriStr = uri.toString()
-        String scheme = uri.getScheme()
-        // Leave local paths alone: 'file' URIs have no authority, so their leading slashes
-        // are part of the path and collapsing them would mangle the key
-        if (scheme == null || scheme == 'file') {
-            return uriStr
-        }
-        String rest = uriStr.substring(scheme.length() + 1)
-        int slashes = 0
-        while (slashes < rest.length() && rest.charAt(slashes) == ('/' as char)) {
-            slashes++
-        }
-        return scheme + '://' + rest.substring(slashes)
     }
 
     /**
@@ -1082,7 +1046,7 @@ final class LaminRunManager {
      * @param labels Labels from the publishDir {@code label} directive (may be null or empty)
      */
     Map<String, Object> createOutputArtifactOnFilePublish(Path source, Path path, List<String> labels) {
-        String pathKey = path.toUri().toString()
+        String pathKey = PathUtils.toUriKey(path)
         Map<String, Object> cachedArtifact = publishedArtifactsByPath.get(pathKey) as Map<String, Object>
         if (cachedArtifact != null) {
             if (labels && config?.features?.use_output_labels != false) {
@@ -1120,7 +1084,7 @@ final class LaminRunManager {
         if (run == null || laminInstance == null || config?.dryRun) {
             return
         }
-        String pathKey = path.toUri().toString()
+        String pathKey = PathUtils.toUriKey(path)
         if (!publishedArtifactsByPath.containsKey(pathKey)) {
             // Path was not captured via onFilePublish – create it now so it is still recorded.
             Map<String, Object> artifact = createOutputArtifact(path, null, null, outputName, null)
@@ -1191,7 +1155,7 @@ final class LaminRunManager {
         }
 
         // Cache so trackWorkflowOutput can find the artifact without creating a duplicate
-        publishedArtifactsByPath.put(path.toUri().toString(), artifact)
+        publishedArtifactsByPath.put(PathUtils.toUriKey(path), artifact)
 
         // Apply any annotations the workflow requested for this file, under both the path it
         // was published from (what the workflow holds) and the path it was published to
@@ -1468,8 +1432,8 @@ final class LaminRunManager {
         }
 
         try {
-            String pathUri = path.toUri().toString()
-            String baseUri = baseDir.toUri().toString()
+            String pathUri = PathUtils.toUriKey(path)
+            String baseUri = PathUtils.toUriKey(baseDir)
 
             if (!baseUri.endsWith('/')) {
                 baseUri += '/'

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -1691,8 +1691,7 @@ final class LaminRunManager {
         }
 
         String logContext = runId != null ? "for run ${runId}" : "without run association"
-        // Note: need to clean path because the protocol can get printed as s3:/ or s3:///
-        String pathStr = path.toUri().toString().replaceAll('^(\\w+)://*', '$1://')
+        String pathStr = PathUtils.toUriKey(path)
         Map<String, Object> artifact = null
         ReentrantLock pathLock = artifactLocks.computeIfAbsent(pathStr) { new ReentrantLock() }
         pathLock.lock()

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -1691,7 +1691,7 @@ final class LaminRunManager {
         }
 
         String logContext = runId != null ? "for run ${runId}" : "without run association"
-        String pathStr = PathUtils.toUriKey(path)
+        String pathStr = PathUtils.toStorageUri(path)
         Map<String, Object> artifact = null
         ReentrantLock pathLock = artifactLocks.computeIfAbsent(pathStr) { new ReentrantLock() }
         pathLock.lock()

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ArtifactConfig.groovy
@@ -23,6 +23,7 @@ import java.util.regex.Pattern
 import nextflow.config.spec.ConfigOption
 import nextflow.config.spec.ConfigScope
 import nextflow.script.dsl.Description
+import ai.lamin.nf_lamin.util.PathUtils
 
 /**
  * Configuration for artifact tracking (input, output, or both).
@@ -248,7 +249,7 @@ class ArtifactConfig implements ConfigScope {
      * @return ArtifactEvaluation with shouldTrack flag and metadata map
      */
     ArtifactEvaluation evaluate(Path path, String artifactDirection, Map workflowParams = [:]) {
-        String pathStr = path.toUri().toString()
+        String pathStr = PathUtils.toUriKey(path)
 
         // Early exit if disabled or direction doesn't match
         if (!enabled) {

--- a/src/main/groovy/ai/lamin/nf_lamin/config/ConfigUtils.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/ConfigUtils.groovy
@@ -26,21 +26,23 @@ import java.util.regex.Pattern
 class ConfigUtils {
 
     /**
-     * Parse a value that can be either a String or a List of Strings into a List.
-     * Normalizes list inputs by converting each element to string and filtering null/empty values.
-     * @param value The value to parse (String, List, or null)
+     * Parse a value that can be either a String or a collection of Strings into a List.
+     * Normalizes inputs by converting each element to a trimmed string and filtering null/empty
+     * values. Accepts any {@code CharSequence}, so a GString from a workflow works as well.
+     * @param value The value to parse (String, Collection, or null)
      * @return List of strings (empty list if null or invalid type)
      */
     static List<String> parseStringOrList(Object value) {
         if (value == null) {
             return []
         }
-        if (value instanceof String) {
-            return value ? [value as String] : []
+        if (value instanceof CharSequence) {
+            String str = value.toString().trim()
+            return str ? [str] : []
         }
-        if (value instanceof List) {
-            // Normalize list: convert each element to string and filter null/empty values
-            return (value as List).collect { it?.toString() }.findAll { it } as List<String>
+        if (value instanceof Collection) {
+            // Normalize collection: convert each element to string and filter null/empty values
+            return (value as Collection).collect { it?.toString()?.trim() }.findAll { it } as List<String>
         }
         return []
     }

--- a/src/main/groovy/ai/lamin/nf_lamin/config/RunConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/RunConfig.groovy
@@ -57,26 +57,7 @@ class RunConfig {
      * @param opts Configuration map with keys: ulabel_uids
      */
     RunConfig(Map opts) {
-        this.ulabel_uids = parseUidList(opts?.ulabel_uids)
-    }
-
-    /**
-     * Parse a UID list from various input types.
-     *
-     * @param value The input value (can be null, String, or List)
-     * @return A list of UIDs
-     */
-    private static List<String> parseUidList(Object value) {
-        if (value == null) {
-            return []
-        }
-        if (value instanceof List) {
-            return value.collect { it?.toString() }.findAll { it }
-        }
-        if (value instanceof String) {
-            return [value]
-        }
-        return []
+        this.ulabel_uids = ConfigUtils.parseStringOrList(opts?.ulabel_uids)
     }
 
     /**

--- a/src/main/groovy/ai/lamin/nf_lamin/config/TransformConfig.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/config/TransformConfig.groovy
@@ -57,26 +57,7 @@ class TransformConfig {
      * @param opts Configuration map with keys: ulabel_uids
      */
     TransformConfig(Map opts) {
-        this.ulabel_uids = parseUidList(opts?.ulabel_uids)
-    }
-
-    /**
-     * Parse a UID list from various input types.
-     *
-     * @param value The input value (can be null, String, or List)
-     * @return A list of UIDs
-     */
-    private static List<String> parseUidList(Object value) {
-        if (value == null) {
-            return []
-        }
-        if (value instanceof List) {
-            return value.collect { it?.toString() }.findAll { it }
-        }
-        if (value instanceof String) {
-            return [value]
-        }
-        return []
+        this.ulabel_uids = ConfigUtils.parseStringOrList(opts?.ulabel_uids)
     }
 
     /**

--- a/src/main/groovy/ai/lamin/nf_lamin/instance/Instance.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/instance/Instance.groovy
@@ -361,6 +361,45 @@ class Instance {
     }
 
     /**
+     * Upsert records in the Lamin API (insert or update based on conflict columns).
+     * @param args A map containing the following keys:
+     *    - moduleName: The name of the module (required)
+     *    - modelName: The name of the model (required)
+     *    - conflictColumns: List of column names to detect conflicts on (required)
+     *    - data: List of record maps to upsert (required)
+     * @return a list of upserted record maps
+     * @throws IllegalStateException if any of the required arguments are null
+     * @throws ApiException if an error occurs while upserting the records
+     */
+    List<Map> upsertRecords(Map args) {
+        String moduleName = args.moduleName as String
+        String modelName = args.modelName as String
+        List<String> conflictColumns = args.conflictColumns as List<String>
+        List<Map> data = args.data as List<Map>
+
+        if (!moduleName) { throw new IllegalStateException('Module name is null. Please check the module name.') }
+        if (!modelName) { throw new IllegalStateException('Model name is null. Please check the model name.') }
+        if (!conflictColumns) { throw new IllegalStateException('Conflict columns is null.') }
+        if (data == null) { throw new IllegalStateException('Data is null.') }
+
+        Body body = new Body(data)
+
+        log.trace "PUT upsertRecords: ${moduleName}.${modelName}, conflictColumns=${conflictColumns}, data=${data}"
+        List<Map> response = callApi { String accessToken ->
+            this.recordsApi.upsertRecordsInstancesInstanceIdModulesModuleNameModelNameUpsertPut(
+                moduleName,
+                modelName,
+                this.settings.id,
+                conflictColumns,
+                body,
+                accessToken
+            )
+        } as List<Map>
+        log.trace "Response from upsertRecords: ${response}"
+        return response ?: []
+    }
+
+    /**
      * Update a record in the Lamin API
      * @param args A map containing the following keys:
      *    - moduleName: The name of the module (required)

--- a/src/main/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotation.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotation.groovy
@@ -18,6 +18,8 @@ package ai.lamin.nf_lamin.model
 
 import groovy.transform.CompileStatic
 
+import ai.lamin.nf_lamin.config.ConfigUtils
+
 /**
  * Metadata a workflow asks to be attached to the artifact of a given path.
  *
@@ -29,9 +31,6 @@ class ArtifactAnnotation {
 
     /** Option names accepted by {@code annotateArtifact()}. */
     static final List<String> ACCEPTED_KEYS = ['kind', 'description', 'ulabel_uids', 'project_uids']
-
-    /** Artifact kinds accepted by LaminDB, see {@code lamindb.base.types.ArtifactKind}. */
-    static final List<String> VALID_KINDS = ['dataset', 'model', 'plan', '__lamindb_run__', '__lamindb_config__']
 
     /** Artifact kind, or null to leave it unchanged. */
     final String kind
@@ -82,11 +81,6 @@ class ArtifactAnnotation {
         }
 
         String kind = opts.get('kind') as String
-        if (kind != null && !VALID_KINDS.contains(kind)) {
-            throw new IllegalArgumentException(
-                "annotateArtifact: invalid kind '${kind}'. Accepted kinds are: ${VALID_KINDS.join(', ')}"
-            )
-        }
 
         Object rawDescription = opts.get('description')
         String description = rawDescription != null ? rawDescription.toString() : null
@@ -94,31 +88,9 @@ class ArtifactAnnotation {
         return new ArtifactAnnotation(
             kind,
             description,
-            toUidList(opts.get('ulabel_uids'), 'ulabel_uids'),
-            toUidList(opts.get('project_uids'), 'project_uids')
+            ConfigUtils.parseStringOrList(opts.get('ulabel_uids')),
+            ConfigUtils.parseStringOrList(opts.get('project_uids'))
         )
-    }
-
-    /**
-     * Normalise a UID option to a list of strings, accepting a bare value as a single entry.
-     */
-    private static List<String> toUidList(Object value, String optionName) {
-        if (value == null) {
-            return []
-        }
-        Collection<?> items = value instanceof Collection ? (Collection) value : [value]
-        List<String> uids = []
-        for (Object item : items) {
-            if (item == null) {
-                continue
-            }
-            String uid = item.toString().trim()
-            if (!uid) {
-                continue
-            }
-            uids.add(uid)
-        }
-        return uids
     }
 
     /**

--- a/src/main/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotation.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotation.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025, Lamin Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.lamin.nf_lamin.model
+
+import groovy.transform.CompileStatic
+
+/**
+ * Metadata a workflow asks to be attached to the artifact of a given path.
+ *
+ * Built from the named arguments of {@code annotateArtifact()} and applied by
+ * {@link ai.lamin.nf_lamin.LaminRunManager} once the artifact for that path exists.
+ */
+@CompileStatic
+class ArtifactAnnotation {
+
+    /** Option names accepted by {@code annotateArtifact()}. */
+    static final List<String> ACCEPTED_KEYS = ['kind', 'description', 'ulabel_uids', 'project_uids']
+
+    /** Artifact kinds accepted by LaminDB, see {@code lamindb.base.types.ArtifactKind}. */
+    static final List<String> VALID_KINDS = ['dataset', 'model', 'plan', '__lamindb_run__', '__lamindb_config__']
+
+    /** Artifact kind, or null to leave it unchanged. */
+    final String kind
+
+    /** Artifact description, or null to leave it unchanged. */
+    final String description
+
+    /** ULabel UIDs or '?name'/'!name'/'+name' references to link. */
+    final List<String> ulabelUids
+
+    /** Project UIDs or '?name'/'!name'/'+name' references to link. */
+    final List<String> projectUids
+
+    ArtifactAnnotation(String kind, String description, List<String> ulabelUids, List<String> projectUids) {
+        this.kind = kind
+        this.description = description
+        this.ulabelUids = ulabelUids ?: []
+        this.projectUids = projectUids ?: []
+    }
+
+    /**
+     * Build an annotation from the named arguments of {@code annotateArtifact()}.
+     *
+     * Rejects unknown options rather than dropping them, so that a typo surfaces as an error
+     * in the workflow instead of as silently missing metadata in LaminDB.
+     *
+     * @param opts The named arguments (may be null or empty)
+     * @return the parsed annotation
+     * @throws IllegalArgumentException if an option is unknown or has an unusable value
+     */
+    static ArtifactAnnotation fromMap(Map opts) {
+        if (!opts) {
+            return new ArtifactAnnotation(null, null, null, null)
+        }
+
+        List<String> unknown = opts.keySet().collect { it as String } - ACCEPTED_KEYS
+        if (unknown.contains('features')) {
+            throw new IllegalArgumentException(
+                "annotateArtifact: 'features' is not supported yet, see " +
+                'https://github.com/laminlabs/nf-lamin/issues/102'
+            )
+        }
+        if (unknown) {
+            throw new IllegalArgumentException(
+                "annotateArtifact: unknown option(s) ${unknown.join(', ')}. " +
+                "Accepted options are: ${ACCEPTED_KEYS.join(', ')}"
+            )
+        }
+
+        String kind = opts.get('kind') as String
+        if (kind != null && !VALID_KINDS.contains(kind)) {
+            throw new IllegalArgumentException(
+                "annotateArtifact: invalid kind '${kind}'. Accepted kinds are: ${VALID_KINDS.join(', ')}"
+            )
+        }
+
+        Object rawDescription = opts.get('description')
+        String description = rawDescription != null ? rawDescription.toString() : null
+
+        return new ArtifactAnnotation(
+            kind,
+            description,
+            toUidList(opts.get('ulabel_uids'), 'ulabel_uids'),
+            toUidList(opts.get('project_uids'), 'project_uids')
+        )
+    }
+
+    /**
+     * Normalise a UID option to a list of strings, accepting a bare value as a single entry.
+     */
+    private static List<String> toUidList(Object value, String optionName) {
+        if (value == null) {
+            return []
+        }
+        Collection<?> items = value instanceof Collection ? (Collection) value : [value]
+        List<String> uids = []
+        for (Object item : items) {
+            if (item == null) {
+                continue
+            }
+            String uid = item.toString().trim()
+            if (!uid) {
+                continue
+            }
+            uids.add(uid)
+        }
+        return uids
+    }
+
+    /**
+     * Whether this annotation carries anything to apply.
+     */
+    boolean isEmpty() {
+        return !kind && !description && !ulabelUids && !projectUids
+    }
+
+    @Override
+    String toString() {
+        List<String> parts = []
+        if (kind) { parts.add("kind=${kind}" as String) }
+        if (description) { parts.add("description='${description}'" as String) }
+        if (ulabelUids) { parts.add("ulabel_uids=${ulabelUids}" as String) }
+        if (projectUids) { parts.add("project_uids=${projectUids}" as String) }
+        return "ArtifactAnnotation{${parts.join(', ')}}"
+    }
+}

--- a/src/main/groovy/ai/lamin/nf_lamin/nio/LaminS3Path.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/nio/LaminS3Path.groovy
@@ -192,6 +192,19 @@ final class LaminS3Path implements Path {
         return new URI(SCHEME, bucket, "/${key}", null, null)
     }
 
+    /**
+     * The same object addressed with the standard {@code s3://} scheme.
+     *
+     * The {@code lamin-s3://} scheme exists only to attach Lamin-managed credentials to a
+     * bucket, so anything outside this plugin -- the Lamin API in particular -- expects the
+     * underlying {@code s3://} form.
+     *
+     * @return the storage URI, e.g. {@code s3://my-bucket/prefix/file.h5ad}
+     */
+    String toStorageUri() {
+        return "s3://${bucket}/${key}"
+    }
+
     @Override
     Path toAbsolutePath() {
         return this

--- a/src/main/groovy/ai/lamin/nf_lamin/util/PathUtils.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/PathUtils.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025, Lamin Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.lamin.nf_lamin.util
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.file.FileHelper
+import java.nio.file.Path
+
+/**
+ * Utility methods for resolving paths handed to the plugin by a workflow.
+ */
+@Slf4j
+@CompileStatic
+class PathUtils {
+
+    /**
+     * Resolve a value a workflow passed to a plugin function to the paths it refers to.
+     *
+     * Remote paths are resolved with Nextflow's {@code FileHelper.asPath}, so a
+     * {@code s3://} or {@code lamin://} string yields a path on the matching file system.
+     *
+     * @param value    A Path, a path String, or a collection of either
+     * @param fnName   The function name for error messages
+     * @return the resolved paths
+     * @throws IllegalArgumentException if the value is null or of an unsupported type
+     */
+    static List<Path> toPaths(Object value, String fnName) {
+        if (value == null) {
+            throw new IllegalArgumentException("${fnName}: no file given (value is null)")
+        }
+        if (value instanceof Path) {
+            return [(Path) value]
+        }
+        if (value instanceof CharSequence) {
+            return [FileHelper.asPath(value.toString())]
+        }
+        if (value instanceof Collection) {
+            List<Path> paths = []
+            for (Object item : (Collection) value) {
+                paths.addAll(toPaths(item, fnName))
+            }
+            return paths
+        }
+        throw new IllegalArgumentException(
+            "${fnName}: cannot resolve a ${value.getClass().simpleName} to a file, " +
+            'expected a file, a file path, or a collection of either'
+        )
+    }
+
+    /**
+     * Render a path as a URI string that two references to the same file agree on.
+     *
+     * Absolutises and normalises the path so that a relative path matches the absolute one,
+     * and renders remote protocols consistently because some providers print them as
+     * {@code s3:/} or {@code s3:///}.
+     *
+     * @param path The path to render
+     * @return the URI string, or null if the path is null
+     */
+    static String toUriKey(Path path) {
+        if (path == null) {
+            return null
+        }
+        URI uri
+        try {
+            uri = path.toAbsolutePath().normalize().toUri()
+        } catch (Exception e) {
+            log.debug "Could not absolutise ${path}: ${e.message}"
+            uri = path.toUri()
+        }
+
+        String uriStr = uri.toString()
+        String scheme = uri.getScheme()
+        // Leave local paths alone: 'file' URIs have no authority, so their leading slashes
+        // are part of the path and collapsing them would mangle the key
+        if (scheme == null || scheme == 'file') {
+            return uriStr
+        }
+        String rest = uriStr.substring(scheme.length() + 1)
+        int slashes = 0
+        while (slashes < rest.length() && rest.charAt(slashes) == ('/' as char)) {
+            slashes++
+        }
+        return scheme + '://' + rest.substring(slashes)
+    }
+}

--- a/src/main/groovy/ai/lamin/nf_lamin/util/PathUtils.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/PathUtils.groovy
@@ -20,6 +20,8 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.file.FileHelper
 import java.nio.file.Path
+import ai.lamin.nf_lamin.nio.LaminPath
+import ai.lamin.nf_lamin.nio.LaminS3Path
 
 /**
  * Utility methods for resolving paths handed to the plugin by a workflow.
@@ -60,6 +62,29 @@ class PathUtils {
             "${fnName}: cannot resolve a ${value.getClass().simpleName} to a file, " +
             'expected a file, a file path, or a collection of either'
         )
+    }
+
+    /**
+     * Render a path as the URI a service outside the plugin should see.
+     *
+     * The {@code lamin://} and {@code lamin-s3://} schemes are notations of this plugin -- one
+     * addresses an artifact, the other attaches Lamin-managed credentials to a bucket -- and
+     * neither means anything to the Lamin API, so both are rendered as the storage URI they
+     * stand for. Every other path is rendered by {@link #toUriKey}.
+     *
+     * @param path The path to render
+     * @return the storage URI, e.g. {@code s3://my-bucket/prefix/file.h5ad}, or null if the
+     *         path is null
+     */
+    static String toStorageUri(Path path) {
+        if (path == null) {
+            return null
+        }
+        Path storagePath = path instanceof LaminPath ? ((LaminPath) path).resolveToStorage() : path
+        if (storagePath instanceof LaminS3Path) {
+            return ((LaminS3Path) storagePath).toStorageUri()
+        }
+        return toUriKey(storagePath)
     }
 
     /**

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminExtensionTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminExtensionTest.groovy
@@ -103,6 +103,98 @@ class LaminExtensionTest extends Specification {
         extension.getInstanceSlug() == 'my-org/production-db'
     }
 
+    // ========== annotateArtifact tests ==========
+
+    def 'annotateArtifact returns its target unchanged'() {
+        given:
+        Path path = Path.of('/tmp/output.json')
+
+        expect:
+        extension.annotateArtifact([kind: 'dataset'], path).is(path)
+    }
+
+    def 'annotateArtifact is a no-op when no instance is configured'() {
+        given:
+        Path path = Path.of('/tmp/output.json')
+
+        when:
+        extension.annotateArtifact([kind: 'dataset', ulabel_uids: ['+qc']], path)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'annotateArtifact registers the annotation for a path'() {
+        given:
+        def mockInstance = Mock(Instance)
+        LaminRunManager.instance.setCurrentInstance(mockInstance)
+        Path path = Path.of('/tmp/output.json')
+
+        when:
+        extension.annotateArtifact([kind: 'dataset'], path)
+
+        then:
+        pendingAnnotationKeys().contains(path.toUri().toString())
+    }
+
+    def 'annotateArtifact accepts a path given as a string'() {
+        given:
+        def mockInstance = Mock(Instance)
+        LaminRunManager.instance.setCurrentInstance(mockInstance)
+
+        when:
+        def result = extension.annotateArtifact([kind: 'dataset'], '/tmp/output.json')
+
+        then:
+        result == '/tmp/output.json'
+        pendingAnnotationKeys().contains(Path.of('/tmp/output.json').toUri().toString())
+    }
+
+    def 'annotateArtifact annotates every path of a collection'() {
+        given:
+        def mockInstance = Mock(Instance)
+        LaminRunManager.instance.setCurrentInstance(mockInstance)
+        def paths = [Path.of('/tmp/a.json'), Path.of('/tmp/b.json')]
+
+        when:
+        def result = extension.annotateArtifact([kind: 'dataset'], paths)
+
+        then:
+        result.is(paths)
+        pendingAnnotationKeys().containsAll(paths.collect { it.toUri().toString() })
+    }
+
+    def 'annotateArtifact works without named arguments'() {
+        given:
+        Path path = Path.of('/tmp/output.json')
+
+        expect:
+        extension.annotateArtifact(path).is(path)
+    }
+
+    def 'annotateArtifact rejects a target that is not a file'() {
+        when:
+        extension.annotateArtifact([kind: 'dataset'], 42)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('cannot annotate')
+    }
+
+    def 'annotateArtifact rejects unknown options'() {
+        when:
+        extension.annotateArtifact([kynd: 'dataset'], Path.of('/tmp/output.json'))
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    private static Set<String> pendingAnnotationKeys() {
+        def field = LaminRunManager.getDeclaredField('pendingAnnotations')
+        field.accessible = true
+        return (field.get(LaminRunManager.instance) as Map).keySet()
+    }
+
     // ========== Integration-style tests ==========
 
     def 'all extension functions work together'() {

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminExtensionTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminExtensionTest.groovy
@@ -178,7 +178,8 @@ class LaminExtensionTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message.contains('cannot annotate')
+        e.message.contains('annotateArtifact')
+        e.message.contains('cannot resolve a Integer to a file')
     }
 
     def 'annotateArtifact rejects unknown options'() {

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
@@ -1,6 +1,7 @@
 package ai.lamin.nf_lamin
 
 import ai.lamin.nf_lamin.instance.Instance
+import ai.lamin.nf_lamin.model.ArtifactAnnotation
 import ai.lamin.nf_lamin.model.RunStatus
 import nextflow.Session
 import nextflow.exception.AbortSignalException
@@ -168,5 +169,198 @@ class LaminRunManagerTest extends Specification {
         'SIGINT from local Ctrl+C'     | false   | false     | new AbortSignalException(new Signal('INT'))    || RunStatus.ABORTED
         'task failure'                 | false   | false     | new RuntimeException('task failed')            || RunStatus.ERRORED
         'error without cause'          | false   | false     | null                                           || RunStatus.ERRORED
+    }
+
+    // ========== annotateArtifact ==========
+
+    /**
+     * A remote path, since local paths are never tracked as artifacts.
+     */
+    private Path remotePath(String uri) {
+        def path = Stub(Path)
+        path.toUri() >> new URI(uri)
+        path.toAbsolutePath() >> path
+        path.normalize() >> path
+        return path
+    }
+
+    private static LaminRunManager annotatingManager(Instance mockInstance) {
+        def manager = LaminRunManager.instance
+        manager.setCurrentInstance(mockInstance)
+        injectField(manager, 'config', new LaminConfig([instance: 'org/inst', api_key: 'key']))
+        injectField(manager, 'run', [uid: 'R1', id: 1])
+        return manager
+    }
+
+    private static Set<String> readKeys(String fieldName) {
+        def field = LaminRunManager.getDeclaredField(fieldName)
+        field.accessible = true
+        def value = field.get(LaminRunManager.instance)
+        return (value instanceof Map ? (value as Map).keySet() : value) as Set<String>
+    }
+
+    def 'applies an annotation registered before the file is published'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = annotatingManager(mockInstance)
+        def source = remotePath('s3://bucket/work/output.json')
+        def target = remotePath('s3://bucket/results/output.json')
+
+        mockInstance.getArtifactByPath(_) >> null
+        mockInstance.createArtifact(_) >> [uid: 'A1', id: 11, run: 1]
+        mockInstance.getRecord(_) >> [uid: 'ulab1234', id: 5]
+
+        when: 'the workflow annotates the file it holds, before it is published'
+        manager.registerAnnotation(source, ArtifactAnnotation.fromMap([
+            kind: 'dataset',
+            description: 'Summary',
+            ulabel_uids: ['ulab1234']
+        ]))
+        manager.createOutputArtifactOnFilePublish(source, target, null)
+
+        then:
+        1 * mockInstance.updateRecord({ Map args ->
+            args.uid == 'A1' && args.data.kind == 'dataset' && args.data.description == 'Summary'
+        })
+        1 * mockInstance.upsertRecord({ Map args ->
+            args.modelName == 'artifactulabel' && args.data.artifact_id == 11 && args.data.ulabel_id == 5
+        })
+    }
+
+    def 'applies an annotation registered after the file was published'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = annotatingManager(mockInstance)
+        def source = remotePath('s3://bucket/work/output.json')
+        def target = remotePath('s3://bucket/results/output.json')
+
+        mockInstance.getArtifactByPath(_) >> null
+        mockInstance.createArtifact(_) >> [uid: 'A1', id: 11, run: 1]
+
+        when: 'publishing wins the race with the map operator'
+        manager.createOutputArtifactOnFilePublish(source, target, null)
+        manager.registerAnnotation(source, ArtifactAnnotation.fromMap([kind: 'dataset']))
+        manager.awaitArtifactTasks()
+
+        then:
+        1 * mockInstance.updateRecord({ Map args -> args.uid == 'A1' && args.data.kind == 'dataset' })
+    }
+
+    def 'annotates an artifact under the path it was published to'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = annotatingManager(mockInstance)
+        def source = remotePath('s3://bucket/work/output.json')
+        def target = remotePath('s3://bucket/results/output.json')
+
+        mockInstance.getArtifactByPath(_) >> null
+        mockInstance.createArtifact(_) >> [uid: 'A1', id: 11, run: 1]
+
+        when:
+        manager.registerAnnotation(target, ArtifactAnnotation.fromMap([kind: 'dataset']))
+        manager.createOutputArtifactOnFilePublish(source, target, null)
+
+        then:
+        1 * mockInstance.updateRecord({ Map args -> args.uid == 'A1' })
+    }
+
+    def 'applies every annotation registered for the same file'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = annotatingManager(mockInstance)
+        def source = remotePath('s3://bucket/work/output.json')
+        def target = remotePath('s3://bucket/results/output.json')
+
+        mockInstance.getArtifactByPath(_) >> null
+        mockInstance.createArtifact(_) >> [uid: 'A1', id: 11, run: 1]
+        mockInstance.getRecord(_) >> [uid: 'ulab1234', id: 5]
+
+        when:
+        manager.registerAnnotation(source, ArtifactAnnotation.fromMap([kind: 'dataset']))
+        manager.registerAnnotation(source, ArtifactAnnotation.fromMap([ulabel_uids: ['ulab1234']]))
+        manager.createOutputArtifactOnFilePublish(source, target, null)
+
+        then:
+        1 * mockInstance.updateRecord({ Map args -> args.data.kind == 'dataset' })
+        1 * mockInstance.upsertRecord({ Map args -> args.modelName == 'artifactulabel' })
+    }
+
+    def 'annotates an input artifact'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = annotatingManager(mockInstance)
+        def input = remotePath('s3://bucket/inputs/reads.fastq')
+
+        mockInstance.getArtifactByPath(_) >> null
+        mockInstance.createArtifact(_) >> [uid: 'A2', id: 22, run: 1]
+
+        when:
+        manager.registerAnnotation(input, ArtifactAnnotation.fromMap([description: 'Raw reads']))
+        manager.createInputArtifact(input)
+
+        then:
+        1 * mockInstance.updateRecord({ Map args -> args.uid == 'A2' && args.data.description == 'Raw reads' })
+    }
+
+    def 'ignores an empty annotation'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = annotatingManager(mockInstance)
+
+        when:
+        manager.registerAnnotation(remotePath('s3://bucket/work/output.json'), ArtifactAnnotation.fromMap([:]))
+
+        then:
+        readKeys('pendingAnnotations').isEmpty()
+    }
+
+    def 'ignores an annotation when no instance is configured'() {
+        given:
+        def manager = LaminRunManager.instance
+
+        when:
+        manager.registerAnnotation(remotePath('s3://bucket/work/output.json'),
+            ArtifactAnnotation.fromMap([kind: 'dataset']))
+
+        then:
+        readKeys('pendingAnnotations').isEmpty()
+    }
+
+    def 'does not apply annotations in dry-run mode'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = LaminRunManager.instance
+        manager.setCurrentInstance(mockInstance)
+        injectField(manager, 'config', new LaminConfig([instance: 'org/inst', api_key: 'key', dry_run: true]))
+
+        when:
+        manager.registerAnnotation(remotePath('s3://bucket/work/output.json'),
+            ArtifactAnnotation.fromMap([kind: 'dataset']))
+
+        then:
+        readKeys('pendingAnnotations').isEmpty()
+        0 * mockInstance.updateRecord(_)
+    }
+
+    def 'reports annotations that never matched an artifact'() {
+        given:
+        def mockInstance = Mock(Instance)
+        def manager = annotatingManager(mockInstance)
+        def published = remotePath('s3://bucket/work/published.json')
+        def target = remotePath('s3://bucket/results/published.json')
+        def neverPublished = remotePath('s3://bucket/work/dropped.json')
+
+        mockInstance.getArtifactByPath(_) >> null
+        mockInstance.createArtifact(_) >> [uid: 'A1', id: 11, run: 1]
+
+        when:
+        manager.registerAnnotation(published, ArtifactAnnotation.fromMap([kind: 'dataset']))
+        manager.registerAnnotation(neverPublished, ArtifactAnnotation.fromMap([kind: 'dataset']))
+        manager.createOutputArtifactOnFilePublish(published, target, null)
+        manager.warnUnmatchedAnnotations()
+
+        then:
+        readKeys('matchedAnnotationKeys') == ['s3://bucket/work/published.json'] as Set
+        readKeys('pendingAnnotations').contains('s3://bucket/work/dropped.json')
     }
 }

--- a/src/test/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotationTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotationTest.groovy
@@ -1,0 +1,102 @@
+package ai.lamin.nf_lamin.model
+
+import spock.lang.Specification
+
+class ArtifactAnnotationTest extends Specification {
+
+    def 'parses all accepted options'() {
+        when:
+        def annotation = ArtifactAnnotation.fromMap([
+            kind: 'dataset',
+            description: 'Aligned reads',
+            ulabel_uids: ['abc123', '+qc-passed'],
+            project_uids: ['proj123']
+        ])
+
+        then:
+        annotation.kind == 'dataset'
+        annotation.description == 'Aligned reads'
+        annotation.ulabelUids == ['abc123', '+qc-passed']
+        annotation.projectUids == ['proj123']
+        !annotation.isEmpty()
+    }
+
+    def 'treats a null or empty map as an empty annotation'() {
+        expect:
+        ArtifactAnnotation.fromMap(opts).isEmpty()
+
+        where:
+        opts << [null, [:]]
+    }
+
+    def 'accepts a bare string for uid options'() {
+        when:
+        def annotation = ArtifactAnnotation.fromMap([ulabel_uids: '+qc-passed', project_uids: 'proj123'])
+
+        then:
+        annotation.ulabelUids == ['+qc-passed']
+        annotation.projectUids == ['proj123']
+    }
+
+    def 'drops null and blank uid entries'() {
+        when:
+        def annotation = ArtifactAnnotation.fromMap([ulabel_uids: ['abc', null, '  ', ' def ']])
+
+        then:
+        annotation.ulabelUids == ['abc', 'def']
+    }
+
+    def 'renders a GString description as a string'() {
+        given:
+        def sample = 'S001'
+
+        when:
+        def annotation = ArtifactAnnotation.fromMap([description: "Reads for ${sample}"])
+
+        then:
+        annotation.description instanceof String
+        annotation.description == 'Reads for S001'
+    }
+
+    def 'rejects unknown options'() {
+        when:
+        ArtifactAnnotation.fromMap([kind: 'dataset', kinds: 'dataset'])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('kinds')
+        e.message.contains('Accepted options')
+    }
+
+    def 'rejects features with a pointer to the tracking issue'() {
+        when:
+        ArtifactAnnotation.fromMap([features: [sample_id: 'S001']])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('not supported yet')
+        e.message.contains('nf-lamin/issues/102')
+    }
+
+    def 'rejects an invalid kind'() {
+        when:
+        ArtifactAnnotation.fromMap([kind: 'report'])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("invalid kind 'report'")
+    }
+
+    def 'accepts every kind LaminDB knows'() {
+        expect:
+        ArtifactAnnotation.fromMap([kind: kind]).kind == kind
+
+        where:
+        kind << ArtifactAnnotation.VALID_KINDS
+    }
+
+    def 'is empty when only unset options are given'() {
+        expect:
+        ArtifactAnnotation.fromMap([kind: null, ulabel_uids: []]).isEmpty()
+    }
+}

--- a/src/test/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotationTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/model/ArtifactAnnotationTest.groovy
@@ -78,21 +78,12 @@ class ArtifactAnnotationTest extends Specification {
         e.message.contains('nf-lamin/issues/102')
     }
 
-    def 'rejects an invalid kind'() {
-        when:
-        ArtifactAnnotation.fromMap([kind: 'report'])
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message.contains("invalid kind 'report'")
-    }
-
-    def 'accepts every kind LaminDB knows'() {
+    def 'passes the kind through as given'() {
         expect:
         ArtifactAnnotation.fromMap([kind: kind]).kind == kind
 
         where:
-        kind << ArtifactAnnotation.VALID_KINDS
+        kind << ['dataset', 'model', 'plan', '__lamindb_run__', 'some-future-kind']
     }
 
     def 'is empty when only unset options are given'() {

--- a/src/test/groovy/ai/lamin/nf_lamin/nio/LaminS3PathTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/nio/LaminS3PathTest.groovy
@@ -413,6 +413,18 @@ class LaminS3PathTest extends Specification {
         uri.host == 'my-bucket'
     }
 
+    // ==================== toStorageUri ====================
+
+    def "toStorageUri() renders the path with the s3:// scheme"() {
+        expect:
+        path('prefix/file.txt').toStorageUri() == 's3://my-bucket/prefix/file.txt'
+    }
+
+    def "toStorageUri() handles a key with a dot-directory"() {
+        expect:
+        path('9fm7UN13/.lamindb/abc0000.yaml').toStorageUri() == 's3://my-bucket/9fm7UN13/.lamindb/abc0000.yaml'
+    }
+
     // ==================== toAbsolutePath / toRealPath ====================
 
     def "toAbsolutePath() returns self"() {

--- a/src/test/groovy/ai/lamin/nf_lamin/util/PathUtilsTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/util/PathUtilsTest.groovy
@@ -19,6 +19,11 @@ package ai.lamin.nf_lamin.util
 import spock.lang.Specification
 import java.nio.file.Path
 
+import ai.lamin.nf_lamin.nio.LaminS3FileSystem
+import ai.lamin.nf_lamin.nio.LaminS3FileSystemProvider
+import ai.lamin.nf_lamin.nio.LaminS3Path
+import software.amazon.awssdk.services.s3.S3Client as AwsS3Client
+
 class PathUtilsTest extends Specification {
 
     // ========== toPaths tests ==========
@@ -93,5 +98,38 @@ class PathUtilsTest extends Specification {
     def 'toUriKey normalises a path with . and .. segments'() {
         expect:
         PathUtils.toUriKey(Path.of('/tmp/sub/../output.json')) == 'file:///tmp/output.json'
+    }
+
+    def 'toUriKey keeps the plugin-only lamin-s3 scheme'() {
+        expect:
+        PathUtils.toUriKey(laminS3Path('prefix/file.txt')) == 'lamin-s3://my-bucket/prefix/file.txt'
+    }
+
+    // ========== toStorageUri tests ==========
+
+    def 'toStorageUri returns null for a null path'() {
+        expect:
+        PathUtils.toStorageUri(null) == null
+    }
+
+    def 'toStorageUri renders a lamin-s3 path with the s3 scheme'() {
+        expect:
+        PathUtils.toStorageUri(laminS3Path('9fm7UN13/.lamindb/abc0000.yaml')) ==
+            's3://my-bucket/9fm7UN13/.lamindb/abc0000.yaml'
+    }
+
+    def 'toStorageUri leaves an ordinary path to toUriKey'() {
+        given:
+        Path path = Path.of('/tmp/output.json')
+
+        expect:
+        PathUtils.toStorageUri(path) == PathUtils.toUriKey(path)
+    }
+
+    private LaminS3Path laminS3Path(String key) {
+        def fs = new LaminS3FileSystem(
+            Mock(LaminS3FileSystemProvider), 's3://my-bucket/prefix', Mock(AwsS3Client), 'key1'
+        )
+        return new LaminS3Path(fs, key)
     }
 }

--- a/src/test/groovy/ai/lamin/nf_lamin/util/PathUtilsTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/util/PathUtilsTest.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025, Lamin Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.lamin.nf_lamin.util
+
+import spock.lang.Specification
+import java.nio.file.Path
+
+class PathUtilsTest extends Specification {
+
+    // ========== toPaths tests ==========
+
+    def 'toPaths returns a single path as is'() {
+        given:
+        Path path = Path.of('/tmp/output.json')
+
+        expect:
+        PathUtils.toPaths(path, 'myFunction') == [path]
+    }
+
+    def 'toPaths resolves a path string'() {
+        expect:
+        PathUtils.toPaths('/tmp/output.json', 'myFunction') == [Path.of('/tmp/output.json')]
+    }
+
+    def 'toPaths resolves a GString'() {
+        given:
+        def name = 'output'
+
+        expect:
+        PathUtils.toPaths("/tmp/${name}.json", 'myFunction') == [Path.of('/tmp/output.json')]
+    }
+
+    def 'toPaths flattens a nested collection'() {
+        expect:
+        PathUtils.toPaths([Path.of('/tmp/a.json'), ['/tmp/b.json']], 'myFunction') ==
+            [Path.of('/tmp/a.json'), Path.of('/tmp/b.json')]
+    }
+
+    def 'toPaths rejects null'() {
+        when:
+        PathUtils.toPaths(null, 'myFunction')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('myFunction')
+        e.message.contains('null')
+    }
+
+    def 'toPaths rejects an unsupported type'() {
+        when:
+        PathUtils.toPaths(42, 'myFunction')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains('myFunction')
+        e.message.contains('cannot resolve a Integer to a file')
+    }
+
+    // ========== toUriKey tests ==========
+
+    def 'toUriKey returns null for a null path'() {
+        expect:
+        PathUtils.toUriKey(null) == null
+    }
+
+    def 'toUriKey absolutises a relative path'() {
+        given:
+        Path relative = Path.of('output.json')
+
+        expect:
+        PathUtils.toUriKey(relative) == relative.toAbsolutePath().toUri().toString()
+    }
+
+    def 'toUriKey keeps the leading slashes of a local path'() {
+        expect:
+        PathUtils.toUriKey(Path.of('/tmp/output.json')) == 'file:///tmp/output.json'
+    }
+
+    def 'toUriKey normalises a path with . and .. segments'() {
+        expect:
+        PathUtils.toUriKey(Path.of('/tmp/sub/../output.json')) == 'file:///tmp/output.json'
+    }
+}

--- a/validation/legacy_syntax_parser/main.nf
+++ b/validation/legacy_syntax_parser/main.nf
@@ -1,4 +1,4 @@
-include { getRunUid; getTransformUid } from 'plugin/nf-lamin'
+include { getRunUid; getTransformUid; getInstanceSlug; annotateArtifact } from 'plugin/nf-lamin'
 
 /*
   Parameters
@@ -30,12 +30,13 @@ process summarizeData {
     id: id,
     runUid: runUid,
     transformUid: transformUid,
-    inputFileSize: input.size()
+    inputFileSize: input.size(),
+    datetime: new Date().toString()
   ]
   """
-  cat > output.json << EOF
-  ${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
-  EOF
+cat > output.json << EOF
+${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
+EOF
   """
 }
 
@@ -62,12 +63,23 @@ workflow {
     log.error "Failed to read artifact via lamin:// path: ${e.message}"
   }
 
+  // log instance slug
+  log.info "Instance slug: ${getInstanceSlug()}"
+
   // create output channel
   ch_out = channel.fromList([
     ["artifact1", artPath1]
   ])
     | view{it -> "Before publish: $it"}
     | summarizeData
+    | map { id, result ->
+        annotateArtifact(result,
+          kind: 'dataset',
+          description: "Summarized output for sample ${id}",
+          ulabel_uids: ['+validation']
+        )
+        [id, result]
+      }
     | view{it -> "After publish: $it"}
 
   // publish:

--- a/validation/legacy_syntax_parser/main.nf
+++ b/validation/legacy_syntax_parser/main.nf
@@ -1,4 +1,4 @@
-include { getRunUid; getTransformUid } from 'plugin/nf-lamin'
+include { getRunUid; getTransformUid; getInstanceSlug; annotateArtifact } from 'plugin/nf-lamin'
 
 /*
   Parameters
@@ -30,12 +30,13 @@ process summarizeData {
     id: id,
     runUid: runUid,
     transformUid: transformUid,
-    inputFileSize: input.size()
+    inputFileSize: input.size(),
+    datetime: new Date().toString()
   ]
   """
-  cat > output.json << EOF
-  ${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
-  EOF
+cat > output.json << EOF
+${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
+EOF
   """
 }
 
@@ -62,12 +63,24 @@ workflow {
     log.error "Failed to read artifact via lamin:// path: ${e.message}"
   }
 
+  // log instance slug
+  log.info "Instance slug: ${getInstanceSlug()}"
+
   // create output channel
   ch_out = channel.fromList([
     ["artifact1", artPath1]
   ])
     | view{it -> "Before publish: $it"}
     | summarizeData
+    | map { id, result ->
+        annotateArtifact(result,
+          kind: 'dataset',
+          description: "Summarized output for sample ${id}",
+          ulabel_uids: ['validation'],
+          features: [sample_id: id]
+        )
+        [id, result]
+      }
     | view{it -> "After publish: $it"}
 
   // publish:

--- a/validation/run/main.nf
+++ b/validation/run/main.nf
@@ -7,7 +7,7 @@
 
 nextflow.enable.types = true
 
-include { getRunUid; getTransformUid } from 'plugin/nf-lamin'
+include { getRunUid; getTransformUid; getInstanceSlug; annotateArtifact } from 'plugin/nf-lamin'
 
 /*
   Typed parameters (Nextflow 26.04+).
@@ -54,12 +54,13 @@ process summarizeData {
     id: id,
     runUid: runUid,
     transformUid: transformUid,
-    inputFileSize: artifact.size()
+    inputFileSize: artifact.size(),
+    datetime: new Date().toString()
   ]
   """
-  cat > output.json << EOF
-  ${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
-  EOF
+cat > output.json << EOF
+${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
+EOF
   """
 }
 
@@ -99,9 +100,20 @@ workflow {
     log.error "Failed to read artifact via lamin:// path: ${e.message}"
   }
 
+  log.info "Instance slug: ${getInstanceSlug()}"
+
   // Construct typed record channel and run named workflow
   ch_input = channel.of(record(id: "artifact1", artifact: artPath))
   ch_results = SUMMARIZE_ARTIFACTS(ch_input)
+    | map { r ->
+        annotateArtifact(r.result,
+          kind: 'dataset',
+          description: "Summarized output for sample ${r.id}",
+          ulabel_uids: ['validation'],
+          features: [sample_id: r.id]
+        )
+        r
+      }
 
   publish:
   results = ch_results

--- a/validation/run/main.nf
+++ b/validation/run/main.nf
@@ -7,7 +7,7 @@
 
 nextflow.enable.types = true
 
-include { getRunUid; getTransformUid } from 'plugin/nf-lamin'
+include { getRunUid; getTransformUid; getInstanceSlug; annotateArtifact } from 'plugin/nf-lamin'
 
 /*
   Typed parameters (Nextflow 26.04+).
@@ -54,12 +54,13 @@ process summarizeData {
     id: id,
     runUid: runUid,
     transformUid: transformUid,
-    inputFileSize: artifact.size()
+    inputFileSize: artifact.size(),
+    datetime: new Date().toString()
   ]
   """
-  cat > output.json << EOF
-  ${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
-  EOF
+cat > output.json << EOF
+${groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(metadata))}
+EOF
   """
 }
 
@@ -99,9 +100,19 @@ workflow {
     log.error "Failed to read artifact via lamin:// path: ${e.message}"
   }
 
+  log.info "Instance slug: ${getInstanceSlug()}"
+
   // Construct typed record channel and run named workflow
   ch_input = channel.of(record(id: "artifact1", artifact: artPath))
   ch_results = SUMMARIZE_ARTIFACTS(ch_input)
+    .map { r ->
+      annotateArtifact(r.result,
+        kind: 'dataset',
+        description: "Summarized output for sample ${r.id}",
+        ulabel_uids: ['+validation']
+      )
+      r
+    }
 
   publish:
   results = ch_results


### PR DESCRIPTION
This PR adds an `annotateArtifact()` DSL function, so a workflow can decide the kind,
description, ulabels and projects of an output artifact programmatically instead of only
through static config.

```groovy
ch_out | map { f -> annotateArtifact(f, kind: 'dataset', ulabel_uids: ['+qc-passed']) }
```

Related to #102 and https://github.com/pfizer-collab/laminlabs/issues/683. It does not close these issues however, since it does not support adding features to artifacts. This will be tackled in a separate PR.