### PR TITLE
✨ Resolve toRealPath() to the underlying storage path

### DIFF
--- a/src/main/groovy/ai/lamin/nf_lamin/nio/LaminPath.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/nio/LaminPath.groovy
@@ -361,10 +361,27 @@ final class LaminPath implements Path {
         return this
     }
 
+    /**
+     * Resolve this lamin:// path to its underlying storage path, like a symlink
+     * resolving to its target (see {@link #resolveToStorage()}). With
+     * {@link LinkOption#NOFOLLOW_LINKS} the path is returned as-is.
+     *
+     * @throws IOException if the artifact cannot be resolved
+     */
     @Override
     Path toRealPath(LinkOption... options) throws IOException {
-        // Return self - the "real" path is resolved at file operation time
-        return this
+        if (options.contains(LinkOption.NOFOLLOW_LINKS)) {
+            return this
+        }
+        try {
+            return resolveToStorage()
+        }
+        catch (IOException e) {
+            throw e
+        }
+        catch (Exception e) {
+            throw new IOException("Cannot resolve ${toUriString()} to its underlying storage path", e)
+        }
     }
 
     @Override

--- a/src/test/groovy/ai/lamin/nf_lamin/nio/LaminPathTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/nio/LaminPathTest.groovy
@@ -573,12 +573,42 @@ class LaminPathTest extends Specification {
 
     // ==================== toRealPath Tests ====================
 
-    def "toRealPath should return self"() {
+    def "toRealPath should resolve to the underlying storage path"() {
+        given:
+        def path = createPath('lamin://laminlabs/lamindata/artifact/uid123')
+        def storagePath = java.nio.file.Paths.get('/storage/.lamindb/uid123.csv')
+
+        when:
+        def result = path.toRealPath()
+
+        then:
+        1 * provider.resolveToUnderlyingPath(path) >> storagePath
+        result.is(storagePath)
+    }
+
+    def "toRealPath with NOFOLLOW_LINKS should return self"() {
         given:
         def path = createPath('lamin://laminlabs/lamindata/artifact/uid123')
 
-        expect:
-        path.toRealPath().is(path)
+        when:
+        def result = path.toRealPath(java.nio.file.LinkOption.NOFOLLOW_LINKS)
+
+        then:
+        0 * provider.resolveToUnderlyingPath(_)
+        result.is(path)
+    }
+
+    def "toRealPath should wrap resolution failures in IOException"() {
+        given:
+        def path = createPath('lamin://laminlabs/lamindata/artifact/uid123')
+        provider.resolveToUnderlyingPath(path) >> { throw new IllegalStateException('LaminRunManager not initialized') }
+
+        when:
+        path.toRealPath()
+
+        then:
+        def e = thrown(IOException)
+        e.cause instanceof IllegalStateException
     }
 
     // ==================== toFile Tests ====================


### PR DESCRIPTION
`LaminPath.toRealPath()` now resolves to the underlying storage path (what `resolveToStorage()` returns) instead of returning itself -- like a symlink resolving to its target. This lets generic `java.nio.file.Path` consumers get at the artifact's real name and extension. Fixes #179, enables nextflow-io/nf-schema#217.

* `NOFOLLOW_LINKS` returns the lamin:// path as-is
* resolution failures are wrapped in `IOException` per the `Path` contract

Nextflow core only calls `toRealPath()` on default-filesystem paths, so staging and publishing are unaffected.
