### PR TITLE
🐛 Mark cancelled runs as aborted instead of errored

### DIFF
--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -35,6 +35,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Const
 import nextflow.Session
+import nextflow.exception.AbortSignalException
 import nextflow.file.FileHelper
 import nextflow.script.WorkflowMetadata
 
@@ -599,6 +600,11 @@ final class LaminRunManager {
         if (session.isSuccess()) {
             return RunStatus.COMPLETED
         } else if (session.isCancelled()) {
+            return RunStatus.ABORTED
+        } else if (session.getError() instanceof AbortSignalException) {
+            // Sometimes a Ctrl+C or a cancellation from Seqera Platform might reach
+            // Nextflow as an AbortSignalException rather than setting the cancelled flag.
+            log.info "Run was cancelled by a termination signal (${session.getError().message}); marking run as aborted"
             return RunStatus.ABORTED
         } else {
             return RunStatus.ERRORED

--- a/src/main/groovy/ai/lamin/nf_lamin/model/RunStatus.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/model/RunStatus.groovy
@@ -11,8 +11,10 @@ import groovy.transform.CompileStatic
  * RESTARTED: For workflow restarts (future use)
  * STARTED: When workflow begins execution (onFlowBegin)
  * COMPLETED: When workflow completes successfully (after onFlowComplete, and session.isSuccess())
- * ERRORED: When workflow encounters an error (after onFlowError, and !session.isSuccess() && !session.isCancelled())
- * ABORTED: When workflow is aborted/cancelled (after onFlowError, and !session.isSuccess() && session.isCancelled())
+ * ERRORED: When workflow encounters an error (after onFlowError, and not successful nor cancelled)
+ * ABORTED: When workflow is cancelled by the user, either via session.isCancelled() or a
+ *          termination signal (SIGTERM/SIGINT) that aborts the session with an AbortSignalException,
+ *          e.g. cancelling a run from Seqera Platform or pressing Ctrl+C locally
  */
 @CompileStatic
 enum RunStatus {

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
@@ -1,6 +1,9 @@
 package ai.lamin.nf_lamin
 
 import ai.lamin.nf_lamin.instance.Instance
+import ai.lamin.nf_lamin.model.RunStatus
+import nextflow.Session
+import nextflow.exception.AbortSignalException
 import spock.lang.Specification
 
 import java.lang.reflect.Field
@@ -8,6 +11,7 @@ import java.net.URI
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import sun.misc.Signal
 
 class LaminRunManagerTest extends Specification {
 
@@ -141,5 +145,28 @@ class LaminRunManagerTest extends Specification {
 
         cleanup:
         releaseWorker.countDown()
+    }
+
+    def 'determineRunStatus maps session state to run status'() {
+        given:
+        def manager = LaminRunManager.instance
+        def session = Stub(Session) {
+            isSuccess() >> success
+            isCancelled() >> cancelled
+            getError() >> error
+        }
+        injectField(manager, 'session', session)
+
+        expect:
+        manager.determineRunStatus() == expected
+
+        where:
+        scenario                       | success | cancelled | error                                          || expected
+        'successful run'               | true    | false     | null                                           || RunStatus.COMPLETED
+        'graceful cancel flag'         | false   | true      | null                                           || RunStatus.ABORTED
+        'SIGTERM from Seqera cancel'   | false   | false     | new AbortSignalException(new Signal('TERM'))   || RunStatus.ABORTED
+        'SIGINT from local Ctrl+C'     | false   | false     | new AbortSignalException(new Signal('INT'))    || RunStatus.ABORTED
+        'task failure'                 | false   | false     | new RuntimeException('task failed')            || RunStatus.ERRORED
+        'error without cause'          | false   | false     | null                                           || RunStatus.ERRORED
     }
 }


### PR DESCRIPTION
Cancelling a run from Seqera Platform (or a local Ctrl+C) reaches Nextflow as a SIGTERM/SIGINT, which aborts the session with an `AbortSignalException` rather than flipping `session.isCancelled()`. As a result `determineRunStatus()` fell through to ERRORED.

Fixes #181. Thanks @jorenretel for the report!