### PR TITLE
✨ Store the Seqera Platform watch url on the run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,9 @@ jobs:
             lamin_env: staging
 
           # test latest edge nextflow
-          # NOTE: switch back to validate-run when latest-edge is >= 26.04
           - java_version: 25
             nextflow_version: latest-edge
-            validation_target: validate-legacy
+            validation_target: validate-run
             validation_args: "--input lamin://laminlabs/lamindata/artifact/zZ3rE7ySAoGQtx3A"
             lamin_env: staging
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ nextflowPlugin {
 ### Key Data Models
 
 **Transform**: Pipeline definition (key = repository path, version = git revision)
-**Run**: Single execution (linked to Transform, tracks status + timing)
+**Run**: Single execution (linked to Transform, tracks status + timing, and the Seqera Platform reference)
 **Artifact**: Input/output files (tracks storage path, linked to Run)
 
 ## Research Strategy

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -56,8 +56,7 @@ ln.Run.get("your-run-uid")
 ![](guide/nf_core_scrnaseq_run.png)
 
 Runs executed with `-with-tower` or launched from Seqera Platform additionally get `run.reference` set
-to the Platform watch URL, with `run.reference_type` set to `"Seqera"`. This requires Nextflow 26.04
-or later.
+to the Platform watch URL, with `run.reference_type` set to `"Seqera"`.
 
 → See {doc}`/reference` for the full `nf-lamin` configuration reference.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -55,6 +55,10 @@ ln.Run.get("your-run-uid")
 
 ![](guide/nf_core_scrnaseq_run.png)
 
+Runs executed with `-with-tower` or launched from Seqera Platform additionally get `run.reference` set
+to the Platform watch URL, with `run.reference_type` set to `"Seqera"`. This requires Nextflow 26.04
+or later.
+
 → See {doc}`/reference` for the full `nf-lamin` configuration reference.
 
 → See {doc}`/reference/examples` for ready-to-run examples for existing pipelines.

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -258,9 +258,8 @@ final class LaminRunManager {
     }
 
     /**
-     * Build the `reference` / `reference_type` fields pointing at the Seqera Platform run.
-     *
-     * @return a map with the reference fields, or an empty map
+     * @return the `reference` / `reference_type` fields pointing at the Seqera Platform run,
+     *   or an empty map if there is nothing to update
      */
     private Map<String, Object> runReferenceFields() {
         String reference = SeqeraPlatformHelper.resolveRunReference(session)
@@ -279,16 +278,12 @@ final class LaminRunManager {
 
         WorkflowMetadata wfMetadata = session.getWorkflowMetadata()
 
-        // Collect the fields to update on the run record
         Map<String, Object> updateData = [
             started_at: wfMetadata.start,
             _status_code: RunStatus.STARTED.code
         ] as Map<String, Object>
-
-        // Add Seqera Platform run reference
         updateData.putAll(runReferenceFields())
 
-        // Update the run record
         Map<String, Object> updatedRun = laminInstance.updateRecord(
             moduleName: 'core',
             modelName: 'run',
@@ -645,7 +640,6 @@ final class LaminRunManager {
             updateData.put('report_id', reportArtifactId)
         }
 
-        // Add Seqera Platform run reference
         updateData.putAll(runReferenceFields())
 
         Map<String, Object> updatedRun = laminInstance.updateRecord(

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -48,6 +48,7 @@ import ai.lamin.nf_lamin.instance.PermissionDeniedException
 import ai.lamin.nf_lamin.hub.InstanceSettings
 import ai.lamin.nf_lamin.model.RunStatus
 import ai.lamin.nf_lamin.nio.LaminPath
+import ai.lamin.nf_lamin.util.SeqeraPlatformHelper
 import ai.lamin.nf_lamin.util.TransformInfoHelper
 import ai.lamin.nf_lamin.config.ArtifactConfig
 import ai.lamin.nf_lamin.config.ArtifactEvaluation
@@ -256,6 +257,20 @@ final class LaminRunManager {
         }
     }
 
+    /**
+     * Build the `reference` / `reference_type` fields pointing at the Seqera Platform run.
+     *
+     * @return a map with the reference fields, or an empty map
+     */
+    private Map<String, Object> runReferenceFields() {
+        String reference = SeqeraPlatformHelper.resolveRunReference(session)
+        if (!reference || reference == run?.get('reference')) {
+            return [:]
+        }
+        log.debug "Setting run.reference to '${reference}'"
+        return [reference: reference, reference_type: SeqeraPlatformHelper.REFERENCE_TYPE] as Map<String, Object>
+    }
+
     void startRun() {
         log.debug 'LaminRunManager.startRun'
         if (run == null || laminInstance == null || session == null || config.dryRun) {
@@ -263,14 +278,22 @@ final class LaminRunManager {
         }
 
         WorkflowMetadata wfMetadata = session.getWorkflowMetadata()
+
+        // Collect the fields to update on the run record
+        Map<String, Object> updateData = [
+            started_at: wfMetadata.start,
+            _status_code: RunStatus.STARTED.code
+        ] as Map<String, Object>
+
+        // Add Seqera Platform run reference
+        updateData.putAll(runReferenceFields())
+
+        // Update the run record
         Map<String, Object> updatedRun = laminInstance.updateRecord(
             moduleName: 'core',
             modelName: 'run',
             uid: run.get('uid') as String,
-            data: [
-                started_at: wfMetadata.start,
-                _status_code: RunStatus.STARTED.code
-            ]
+            data: updateData
         )
         if (run.uid != updatedRun.uid) {
             log.warn "Run UID changed from ${run.uid} to ${updatedRun.uid} on start update!"
@@ -621,6 +644,9 @@ final class LaminRunManager {
         if (reportArtifactId != null) {
             updateData.put('report_id', reportArtifactId)
         }
+
+        // Add Seqera Platform run reference
+        updateData.putAll(runReferenceFields())
 
         Map<String, Object> updatedRun = laminInstance.updateRecord(
             moduleName: 'core',

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -272,11 +272,22 @@ final class LaminRunManager {
     }
 
     /**
+     * The reference is read from Nextflow internals, so it never throws: it is a convenience
+     * and must not take the status update it travels with along with it. Catches Throwable
+     * rather than Exception because reflecting into another plugin can raise a linkage error.
+     *
      * @return the `reference` / `reference_type` fields pointing at the Seqera Platform run,
      *   or an empty map if there is nothing to update
      */
     private Map<String, Object> runReferenceFields() {
-        String reference = SeqeraPlatformHelper.resolveRunReference(session)
+        String reference
+        try {
+            reference = SeqeraPlatformHelper.resolveRunReference(session)
+        }
+        catch (Throwable e) {
+            log.debug "Could not read the Seqera Platform watch URL: ${e.message}"
+            return [:]
+        }
         if (!reference || reference == run?.get('reference')) {
             return [:]
         }

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -292,7 +292,7 @@ final class LaminRunManager {
             return [:]
         }
         log.debug "Setting run.reference to '${reference}'"
-        return [reference: reference, reference_type: SeqeraPlatformHelper.REFERENCE_TYPE] as Map<String, Object>
+        return [reference: reference, reference_type: 'Seqera'] as Map<String, Object>
     }
 
     void startRun() {

--- a/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/LaminRunManager.groovy
@@ -272,9 +272,8 @@ final class LaminRunManager {
     }
 
     /**
-     * The reference is read from Nextflow internals, so it never throws: it is a convenience
-     * and must not take the status update it travels with along with it. Catches Throwable
-     * rather than Exception because reflecting into another plugin can raise a linkage error.
+     * Never throws -- the reference must not break the status update it travels with, and
+     * reflecting into another plugin can raise a linkage error rather than an exception.
      *
      * @return the `reference` / `reference_type` fields pointing at the Seqera Platform run,
      *   or an empty map if there is nothing to update

--- a/src/main/groovy/ai/lamin/nf_lamin/instance/Instance.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/instance/Instance.groovy
@@ -644,6 +644,8 @@ class Instance {
      *    - _status_code: The run status code (int, e.g. RunStatus.STARTED.code)
      *    Optional fields:
      *    - name: Run name (String — must be a plain String, not a GString)
+     *    - reference: External reference such as a Seqera Platform watch URL (String, max 255 chars)
+     *    - reference_type: Type of the reference, e.g. "Seqera" (String, max 25 chars)
      *    - space_id: Space ID (int)
      *    - branch_id: Branch ID (int)
      *

--- a/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025, Lamin Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.lamin.nf_lamin.util
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.Session
+
+/**
+ * Reads the Seqera Platform watch URL from the Nextflow session.
+ *
+ * Nextflow 26.04 exposes {@code workflow.platform}
+ * (<a href="https://github.com/nextflow-io/nextflow/pull/6545">nextflow-io/nextflow#6545</a>),
+ * which nf-tower fills with the watch URL. It is read reflectively because neither the
+ * accessor nor the {@code PlatformMetadata} class exists on 25.10, the minimum version.
+ */
+@Slf4j
+@CompileStatic
+class SeqeraPlatformHelper {
+
+    /** Value written to {@code run.reference_type}, matching existing Seqera runs on laminlabs/lamindata. */
+    static final String REFERENCE_TYPE = 'Seqera'
+
+    private SeqeraPlatformHelper() {
+    }
+
+    /**
+     * @param session The current Nextflow session
+     * @return the watch URL, or null if the run is not executing against Seqera Platform
+     */
+    static String resolveRunReference(Session session) {
+        return session != null ? readReference(session.getWorkflowMetadata()) : null
+    }
+
+    /**
+     * Takes an Object rather than a WorkflowMetadata so it can be tested without
+     * Nextflow 26.04 on the compile classpath.
+     *
+     * @param metadata The Nextflow workflow metadata
+     * @return the watch URL, or null if unavailable
+     */
+    static String readReference(Object metadata) {
+        if (metadata == null) {
+            return null
+        }
+        try {
+            Object platform = metadata.getClass().getMethod('getPlatform').invoke(metadata)
+            if (platform == null) {
+                return null
+            }
+            Object url = platform.getClass().getMethod('getWorkflowUrl').invoke(platform)
+            // toString() guarantees a plain String; the API rejects GStrings
+            return url?.toString()?.trim() ?: null
+        }
+        catch (NoSuchMethodException e) {
+            // Nextflow < 26.04: `workflow.platform` does not exist
+            log.debug 'Seqera Platform metadata is not available on this Nextflow version'
+            return null
+        }
+        catch (Exception e) {
+            log.debug "Could not read Seqera Platform metadata: ${e.message}"
+            return null
+        }
+    }
+}

--- a/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
@@ -19,6 +19,7 @@ package ai.lamin.nf_lamin.util
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
+import java.lang.reflect.Field
 
 /**
  * Reads the Seqera Platform watch URL from the Nextflow session.
@@ -27,6 +28,10 @@ import nextflow.Session
  * (<a href="https://github.com/nextflow-io/nextflow/pull/6545">nextflow-io/nextflow#6545</a>),
  * which nf-tower fills with the watch URL. Read reflectively because it does not exist on 25.10,
  * the minimum supported version.
+ *
+ * On 25.10 the URL is only held in a private field of the nf-tower observer, which the session
+ * in turn keeps in a private field, so {@link #readReferenceFromObservers} reaches in for it.
+ * That is a best-effort fallback: anything unexpected yields no reference rather than an error.
  */
 @Slf4j
 @CompileStatic
@@ -34,6 +39,12 @@ class SeqeraPlatformHelper {
 
     /** Matches the {@code reference_type} of the existing Seqera runs on laminlabs/lamindata. */
     static final String REFERENCE_TYPE = 'Seqera'
+
+    /** Session fields holding the trace observers, newest Nextflow first. */
+    private static final List<String> OBSERVER_FIELDS = ['observersV2', 'observers']
+
+    /** The nf-tower observer holding the watch URL; renamed to TowerObserver in 26.04. */
+    private static final List<String> TOWER_OBSERVERS = ['TowerClient', 'TowerObserver']
 
     private SeqeraPlatformHelper() {
     }
@@ -43,7 +54,85 @@ class SeqeraPlatformHelper {
      * @return the watch URL, or null if the run is not executing against Seqera Platform
      */
     static String resolveRunReference(Session session) {
-        return session != null ? readReference(session.getWorkflowMetadata()) : null
+        if (session == null) {
+            return null
+        }
+        String reference = readReference(session.getWorkflowMetadata())
+        return reference ?: readReferenceFromObservers(session)
+    }
+
+    /**
+     * Read the watch URL straight from the nf-tower observer, for Nextflow versions without
+     * {@code workflow.platform}.
+     *
+     * Both the observer list and the URL are private with no accessor, so this reaches in
+     * reflectively. It is deliberately forgiving: a session without observers, without nf-tower,
+     * or with a field layout this does not recognise simply yields null.
+     *
+     * Takes an Object rather than a Session so it can be tested with a stand-in.
+     *
+     * @param session The Nextflow session
+     * @return the watch URL, or null if unavailable
+     */
+    static String readReferenceFromObservers(Object session) {
+        if (session == null) {
+            return null
+        }
+        for (Object observer : findObservers(session)) {
+            if (observer == null || !TOWER_OBSERVERS.contains(observer.getClass().simpleName)) {
+                continue
+            }
+            Object url = readField(observer, 'watchUrl')
+            String reference = url?.toString()?.trim()
+            if (reference) {
+                log.debug "Read the Seqera Platform watch URL from ${observer.getClass().simpleName}"
+                return reference
+            }
+        }
+        return null
+    }
+
+    /**
+     * @param session The Nextflow session
+     * @return the trace observers, or an empty list if they cannot be read
+     */
+    private static Collection<?> findObservers(Object session) {
+        for (String fieldName : OBSERVER_FIELDS) {
+            Object observers = readField(session, fieldName)
+            if (observers instanceof Collection) {
+                return (Collection) observers
+            }
+        }
+        log.debug "Could not find the trace observers on ${session.getClass().simpleName}"
+        return []
+    }
+
+    /**
+     * Read a field by name, walking up the class hierarchy, whatever its visibility.
+     *
+     * @param target    The object to read from
+     * @param fieldName The field to read
+     * @return the value, or null if the field does not exist or cannot be read
+     */
+    private static Object readField(Object target, String fieldName) {
+        for (Class<?> type = target.getClass(); type != null; type = type.getSuperclass()) {
+            Field field
+            try {
+                field = type.getDeclaredField(fieldName)
+            }
+            catch (NoSuchFieldException e) {
+                continue
+            }
+            try {
+                field.setAccessible(true)
+                return field.get(target)
+            }
+            catch (Exception e) {
+                log.debug "Could not read ${type.simpleName}.${fieldName}: ${e.message}"
+                return null
+            }
+        }
+        return null
     }
 
     /**

--- a/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
@@ -26,12 +26,9 @@ import java.lang.reflect.Field
  *
  * Nextflow 26.04 exposes {@code workflow.platform}
  * (<a href="https://github.com/nextflow-io/nextflow/pull/6545">nextflow-io/nextflow#6545</a>),
- * which nf-tower fills with the watch URL. Read reflectively because it does not exist on 25.10,
- * the minimum supported version.
- *
- * On 25.10 the URL is only held in a private field of the nf-tower observer, which the session
- * in turn keeps in a private field, so {@link #readReferenceFromObservers} reaches in for it.
- * That is a best-effort fallback: anything unexpected yields no reference rather than an error.
+ * which nf-tower fills with the watch URL. On 25.10, the minimum supported version, it is only
+ * held in a private field of the nf-tower observer. Both are read reflectively, and anything
+ * unexpected yields no reference rather than an error.
  */
 @Slf4j
 @CompileStatic
@@ -59,14 +56,8 @@ class SeqeraPlatformHelper {
     }
 
     /**
-     * Read the watch URL straight from the nf-tower observer, for Nextflow versions without
-     * {@code workflow.platform}.
-     *
-     * Both the observer list and the URL are private with no accessor, so this reaches in
-     * reflectively. It is deliberately forgiving: a session without observers, without nf-tower,
-     * or with a field layout this does not recognise simply yields null.
-     *
-     * Takes an Object rather than a Session so it can be tested with a stand-in.
+     * Read the watch URL from the nf-tower observer, for Nextflow versions without
+     * {@code workflow.platform}. Takes an Object so it can be tested with a stand-in.
      *
      * @param session The Nextflow session
      * @return the watch URL, or null if unavailable

--- a/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
@@ -24,11 +24,10 @@ import java.lang.reflect.Field
 /**
  * Reads the Seqera Platform watch URL from the Nextflow session.
  *
- * Nextflow 26.04 exposes {@code workflow.platform}
- * (<a href="https://github.com/nextflow-io/nextflow/pull/6545">nextflow-io/nextflow#6545</a>),
- * which nf-tower fills with the watch URL. On 25.10, the minimum supported version, it is only
- * held in a private field of the nf-tower observer. Both are read reflectively, and anything
- * unexpected yields no reference rather than an error.
+ * Nextflow 26.04 exposes {@code workflow.platform} which nf-tower fills with the watch URL.
+ * On 25.10, the minimum supported version, it is only held in a private field of the nf-tower
+ * observer. Both are read reflectively, and anything unexpected yields no reference rather than
+ * an error.
  */
 @Slf4j
 @CompileStatic

--- a/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
@@ -37,9 +37,6 @@ import java.lang.reflect.Field
 @CompileStatic
 class SeqeraPlatformHelper {
 
-    /** Matches the {@code reference_type} of the existing Seqera runs on laminlabs/lamindata. */
-    static final String REFERENCE_TYPE = 'Seqera'
-
     /** Session fields holding the trace observers, newest Nextflow first. */
     private static final List<String> OBSERVER_FIELDS = ['observersV2', 'observers']
 

--- a/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
+++ b/src/main/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelper.groovy
@@ -25,14 +25,14 @@ import nextflow.Session
  *
  * Nextflow 26.04 exposes {@code workflow.platform}
  * (<a href="https://github.com/nextflow-io/nextflow/pull/6545">nextflow-io/nextflow#6545</a>),
- * which nf-tower fills with the watch URL. It is read reflectively because neither the
- * accessor nor the {@code PlatformMetadata} class exists on 25.10, the minimum version.
+ * which nf-tower fills with the watch URL. Read reflectively because it does not exist on 25.10,
+ * the minimum supported version.
  */
 @Slf4j
 @CompileStatic
 class SeqeraPlatformHelper {
 
-    /** Value written to {@code run.reference_type}, matching existing Seqera runs on laminlabs/lamindata. */
+    /** Matches the {@code reference_type} of the existing Seqera runs on laminlabs/lamindata. */
     static final String REFERENCE_TYPE = 'Seqera'
 
     private SeqeraPlatformHelper() {
@@ -47,8 +47,7 @@ class SeqeraPlatformHelper {
     }
 
     /**
-     * Takes an Object rather than a WorkflowMetadata so it can be tested without
-     * Nextflow 26.04 on the compile classpath.
+     * Takes an Object rather than a WorkflowMetadata so it can be tested without Nextflow 26.04.
      *
      * @param metadata The Nextflow workflow metadata
      * @return the watch URL, or null if unavailable
@@ -63,11 +62,10 @@ class SeqeraPlatformHelper {
                 return null
             }
             Object url = platform.getClass().getMethod('getWorkflowUrl').invoke(platform)
-            // toString() guarantees a plain String; the API rejects GStrings
+            // the API rejects GStrings
             return url?.toString()?.trim() ?: null
         }
         catch (NoSuchMethodException e) {
-            // Nextflow < 26.04: `workflow.platform` does not exist
             log.debug 'Seqera Platform metadata is not available on this Nextflow version'
             return null
         }

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
@@ -140,6 +140,43 @@ class LaminRunManagerTest extends Specification {
         }) >> [uid: 'R456']
     }
 
+    def 'startRun stores the watch url and reference type when running on Seqera Platform'() {
+        given:
+        def manager = LaminRunManager.instance
+        def mockInstance = Mock(Instance)
+        manager.setCurrentInstance(mockInstance)
+        injectField(manager, 'config', new LaminConfig([instance: 'testorg/testinst', api_key: 'test-key']))
+        injectField(manager, 'run', [uid: 'R456', id: 99] as Map<String, Object>)
+
+        String watchUrl = 'https://cloud.seqera.io/orgs/o/workspaces/w/watch/b0siCig3qoUvZ'
+        def metadata = new MetadataWithPlatform(platform: new PlatformWithUrl(workflowUrl: watchUrl))
+        injectField(manager, 'session', Stub(Session) { getWorkflowMetadata() >> metadata })
+
+        when:
+        manager.startRun()
+
+        then:
+        1 * mockInstance.updateRecord({ Map args ->
+            Map data = args.data as Map
+            data.get('reference') == watchUrl &&
+            data.get('reference_type') == 'Seqera'
+        }) >> [uid: 'R456']
+    }
+
+    /** Mimics Nextflow >= 26.04, where WorkflowMetadata exposes getPlatform(). */
+    static class MetadataWithPlatform extends WorkflowMetadata {
+
+        Object platform
+
+    }
+
+    /** Mimics nextflow.script.PlatformMetadata. */
+    static class PlatformWithUrl {
+
+        Object workflowUrl
+
+    }
+
     def 'createInputArtifactsAsync returns before worker finishes (non-blocking)'() {
         given:
         def manager = LaminRunManager.instance

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
@@ -171,8 +171,7 @@ class LaminRunManagerTest extends Specification {
         injectField(manager, 'config', new LaminConfig([instance: 'testorg/testinst', api_key: 'test-key']))
         injectField(manager, 'run', [uid: 'R456', id: 99] as Map<String, Object>)
 
-        // startRun reads the metadata first, the reference lookup second -- fail only the
-        // latter, with a linkage error, which is not an Exception and escapes a narrower catch
+        // fail the second metadata read -- the reference lookup -- with a linkage error
         int calls = 0
         def session = Stub(Session) {
             getWorkflowMetadata() >> {

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
@@ -122,7 +122,7 @@ class LaminRunManagerTest extends Specification {
         injectField(manager, 'config', new LaminConfig([instance: 'testorg/testinst', api_key: 'test-key']))
         injectField(manager, 'run', [uid: 'R456', id: 99] as Map<String, Object>)
 
-        // Stub(WorkflowMetadata) has no getPlatform(): this is the Nextflow 25.10 shape
+        // Stub(WorkflowMetadata) has no getPlatform(), like Nextflow 25.10
         def metadata = Stub(WorkflowMetadata) {
             getStart() >> OffsetDateTime.now()
         }

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
@@ -163,6 +163,39 @@ class LaminRunManagerTest extends Specification {
         }) >> [uid: 'R456']
     }
 
+    def 'startRun still marks the run as started when the reference cannot be read'() {
+        given:
+        def manager = LaminRunManager.instance
+        def mockInstance = Mock(Instance)
+        manager.setCurrentInstance(mockInstance)
+        injectField(manager, 'config', new LaminConfig([instance: 'testorg/testinst', api_key: 'test-key']))
+        injectField(manager, 'run', [uid: 'R456', id: 99] as Map<String, Object>)
+
+        // startRun reads the metadata first, the reference lookup second -- fail only the
+        // latter, with a linkage error, which is not an Exception and escapes a narrower catch
+        int calls = 0
+        def session = Stub(Session) {
+            getWorkflowMetadata() >> {
+                if (calls++ > 0) {
+                    throw new NoClassDefFoundError('nextflow/script/PlatformMetadata')
+                }
+                return Stub(WorkflowMetadata) { getStart() >> OffsetDateTime.now() }
+            }
+        }
+        injectField(manager, 'session', session)
+
+        when:
+        manager.startRun()
+
+        then:
+        noExceptionThrown()
+        1 * mockInstance.updateRecord({ Map args ->
+            Map data = args.data as Map
+            data.containsKey('_status_code') &&
+            !data.containsKey('reference')
+        }) >> [uid: 'R456']
+    }
+
     /** Mimics Nextflow >= 26.04, where WorkflowMetadata exposes getPlatform(). */
     static class MetadataWithPlatform extends WorkflowMetadata {
 

--- a/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/LaminRunManagerTest.groovy
@@ -4,11 +4,13 @@ import ai.lamin.nf_lamin.instance.Instance
 import ai.lamin.nf_lamin.model.RunStatus
 import nextflow.Session
 import nextflow.exception.AbortSignalException
+import nextflow.script.WorkflowMetadata
 import spock.lang.Specification
 
 import java.lang.reflect.Field
 import java.net.URI
 import java.nio.file.Path
+import java.time.OffsetDateTime
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import sun.misc.Signal
@@ -110,6 +112,31 @@ class LaminRunManagerTest extends Specification {
             !args.containsKey('space_id')
         }) >> [uid: 'testuid1234567890ab']
         result != null
+    }
+
+    def 'startRun omits the reference when not running on Seqera Platform'() {
+        given:
+        def manager = LaminRunManager.instance
+        def mockInstance = Mock(Instance)
+        manager.setCurrentInstance(mockInstance)
+        injectField(manager, 'config', new LaminConfig([instance: 'testorg/testinst', api_key: 'test-key']))
+        injectField(manager, 'run', [uid: 'R456', id: 99] as Map<String, Object>)
+
+        // Stub(WorkflowMetadata) has no getPlatform(): this is the Nextflow 25.10 shape
+        def metadata = Stub(WorkflowMetadata) {
+            getStart() >> OffsetDateTime.now()
+        }
+        injectField(manager, 'session', Stub(Session) { getWorkflowMetadata() >> metadata })
+
+        when:
+        manager.startRun()
+
+        then:
+        1 * mockInstance.updateRecord({ Map args ->
+            Map data = args.data as Map
+            !data.containsKey('reference') &&
+            !data.containsKey('reference_type')
+        }) >> [uid: 'R456']
     }
 
     def 'createInputArtifactsAsync returns before worker finishes (non-blocking)'() {

--- a/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
@@ -1,0 +1,134 @@
+package ai.lamin.nf_lamin.util
+
+import nextflow.Session
+import nextflow.script.WorkflowMetadata
+import spock.lang.Requires
+import spock.lang.Specification
+
+class SeqeraPlatformHelperTest extends Specification {
+
+    /** Mimics nextflow.script.PlatformMetadata (Nextflow >= 26.04). */
+    static class FakePlatform {
+
+        Object workflowId
+        Object workflowUrl
+
+    }
+
+    /** Mimics nextflow.script.WorkflowMetadata with a `platform` property. */
+    static class FakeMetadata {
+
+        Object platform
+
+    }
+
+    private static FakeMetadata metadataWith(Object url, Object id) {
+        return new FakeMetadata(platform: new FakePlatform(workflowUrl: url, workflowId: id))
+    }
+
+    def 'reads the watch URL'() {
+        given:
+        def metadata = metadataWith('https://cloud.seqera.io/orgs/o/workspaces/w/watch/abc', 'abc')
+
+        expect:
+        SeqeraPlatformHelper.readReference(metadata) == 'https://cloud.seqera.io/orgs/o/workspaces/w/watch/abc'
+    }
+
+    def 'returns null when the watch URL is #scenario, even with a workflow id'() {
+        expect:
+        // the workflow id on its own is not enough to reconstruct the URL, so it is not stored
+        SeqeraPlatformHelper.readReference(metadataWith(url, 'b0siCig3qoUvZ')) == null
+
+        where:
+        scenario      | url
+        'null'        | null
+        'empty'       | ''
+        'whitespace'  | '   '
+    }
+
+    def 'returns null when the platform metadata is empty'() {
+        expect:
+        // Nextflow >= 26.04 without Seqera Platform: getPlatform() lazily returns an empty object
+        SeqeraPlatformHelper.readReference(metadataWith(null, null)) == null
+    }
+
+    def 'returns null when there is no platform metadata at all'() {
+        expect:
+        SeqeraPlatformHelper.readReference(new FakeMetadata(platform: null)) == null
+    }
+
+    def 'returns null on Nextflow versions without workflow.platform'() {
+        expect:
+        // Nextflow 25.10: WorkflowMetadata has no getPlatform() method
+        SeqeraPlatformHelper.readReference(Stub(WorkflowMetadata)) == null
+        SeqeraPlatformHelper.readReference(new Object()) == null
+        SeqeraPlatformHelper.readReference(null) == null
+    }
+
+    def 'returns a plain String, never a GString'() {
+        given:
+        String id = 'b0siCig3qoUvZ'
+        def metadata = metadataWith("https://cloud.seqera.io/watch/${id}", null)
+
+        when:
+        Object reference = SeqeraPlatformHelper.readReference(metadata)
+
+        then:
+        // the Lamin API rejects GStrings
+        reference.getClass() == String
+    }
+
+    def 'resolveRunReference tolerates a missing session or metadata'() {
+        given:
+        def session = Stub(Session) {
+            getWorkflowMetadata() >> null
+        }
+
+        expect:
+        SeqeraPlatformHelper.resolveRunReference(null) == null
+        SeqeraPlatformHelper.resolveRunReference(session) == null
+    }
+
+    def 'reference type is Seqera'() {
+        expect:
+        // matches the reference_type of the existing Seqera runs on laminlabs/lamindata
+        SeqeraPlatformHelper.REFERENCE_TYPE == 'Seqera'
+    }
+
+    /**
+     * Guards the getter names against the real Nextflow classes. The fakes above cannot catch a
+     * typo in 'getPlatform' / 'getWorkflowUrl' / 'getWorkflowId', because a wrong name and a
+     * genuinely absent one both resolve to null. Skipped while the plugin compiles against
+     * Nextflow 25.10; runs as soon as the floor is raised to 26.04.
+     */
+    @Requires({ SeqeraPlatformHelperTest.platformMetadataClass() != null })
+    def 'reads the real Nextflow PlatformMetadata'() {
+        given:
+        def platform = platformMetadataClass().getConstructor().newInstance()
+        platform.workflowId = 'b0siCig3qoUvZ'
+        platform.workflowUrl = 'https://cloud.seqera.io/orgs/o/workspaces/w/watch/b0siCig3qoUvZ'
+
+        expect:
+        WorkflowMetadata.getMethod('getPlatform') != null
+
+        and:
+        SeqeraPlatformHelper.readReference(new FakeMetadata(platform: platform)) ==
+            'https://cloud.seqera.io/orgs/o/workspaces/w/watch/b0siCig3qoUvZ'
+
+        when:
+        platform.workflowUrl = null
+
+        then:
+        SeqeraPlatformHelper.readReference(new FakeMetadata(platform: platform)) == null
+    }
+
+    /** @return the Nextflow >= 26.04 PlatformMetadata class, or null on older versions */
+    static Class platformMetadataClass() {
+        try {
+            return Class.forName('nextflow.script.PlatformMetadata')
+        }
+        catch (ClassNotFoundException e) {
+            return null
+        }
+    }
+}

--- a/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
@@ -36,7 +36,7 @@ class SeqeraPlatformHelperTest extends Specification {
 
     def 'returns null when the watch URL is #scenario, even with a workflow id'() {
         expect:
-        // the workflow id on its own is not enough to reconstruct the URL, so it is not stored
+        // the workflow id alone is not enough to reconstruct the URL
         SeqeraPlatformHelper.readReference(metadataWith(url, 'b0siCig3qoUvZ')) == null
 
         where:
@@ -48,7 +48,7 @@ class SeqeraPlatformHelperTest extends Specification {
 
     def 'returns null when the platform metadata is empty'() {
         expect:
-        // Nextflow >= 26.04 without Seqera Platform: getPlatform() lazily returns an empty object
+        // without Seqera Platform, getPlatform() returns an empty object
         SeqeraPlatformHelper.readReference(metadataWith(null, null)) == null
     }
 
@@ -74,7 +74,6 @@ class SeqeraPlatformHelperTest extends Specification {
         Object reference = SeqeraPlatformHelper.readReference(metadata)
 
         then:
-        // the Lamin API rejects GStrings
         reference.getClass() == String
     }
 
@@ -91,15 +90,13 @@ class SeqeraPlatformHelperTest extends Specification {
 
     def 'reference type is Seqera'() {
         expect:
-        // matches the reference_type of the existing Seqera runs on laminlabs/lamindata
         SeqeraPlatformHelper.REFERENCE_TYPE == 'Seqera'
     }
 
     /**
-     * Guards the getter names against the real Nextflow classes. The fakes above cannot catch a
-     * typo in 'getPlatform' / 'getWorkflowUrl' / 'getWorkflowId', because a wrong name and a
-     * genuinely absent one both resolve to null. Skipped while the plugin compiles against
-     * Nextflow 25.10; runs as soon as the floor is raised to 26.04.
+     * Guards the getter names against the real Nextflow classes -- the fakes above cannot catch a
+     * typo, because a wrong name and an absent one both resolve to null. Skipped until the
+     * Nextflow floor is raised to 26.04.
      */
     @Requires({ SeqeraPlatformHelperTest.platformMetadataClass() != null })
     def 'reads the real Nextflow PlatformMetadata'() {

--- a/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
@@ -152,11 +152,6 @@ class SeqeraPlatformHelperTest extends Specification {
         Session.getDeclaredField('observersV2') != null
     }
 
-    def 'reference type is Seqera'() {
-        expect:
-        SeqeraPlatformHelper.REFERENCE_TYPE == 'Seqera'
-    }
-
     /**
      * Guards the getter names against the real Nextflow classes -- the fakes above cannot catch a
      * typo, because a wrong name and an absent one both resolve to null. Skipped until the

--- a/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
@@ -88,6 +88,70 @@ class SeqeraPlatformHelperTest extends Specification {
         SeqeraPlatformHelper.resolveRunReference(session) == null
     }
 
+    // ========== observer fallback (Nextflow < 26.04) ==========
+
+    /** Mimics the nf-tower observer, which keeps the watch URL in a private field. */
+    static class TowerClient {
+
+        private String watchUrl
+
+        TowerClient(String watchUrl) {
+            this.watchUrl = watchUrl
+        }
+
+    }
+
+    /** Mimics a session, which keeps its observers in a private field. */
+    static class FakeSession {
+
+        private List observersV2
+
+        FakeSession(List observersV2) {
+            this.observersV2 = observersV2
+        }
+
+    }
+
+    def 'reads the watch URL from the nf-tower observer'() {
+        given:
+        def session = new FakeSession([new Object(), new TowerClient('https://cloud.seqera.io/watch/abc')])
+
+        expect:
+        SeqeraPlatformHelper.readReferenceFromObservers(session) ==
+            'https://cloud.seqera.io/watch/abc'
+    }
+
+    def 'returns null when the watch URL on the observer is #scenario'() {
+        expect:
+        SeqeraPlatformHelper.readReferenceFromObservers(new FakeSession([new TowerClient(url)])) == null
+
+        where:
+        scenario     | url
+        'null'       | null
+        'empty'      | ''
+        'whitespace' | '   '
+    }
+
+    def 'returns null when nothing recognisable is there'() {
+        expect:
+        SeqeraPlatformHelper.readReferenceFromObservers(null) == null
+        // no nf-tower observer
+        SeqeraPlatformHelper.readReferenceFromObservers(new FakeSession([new Object()])) == null
+        // no observers at all
+        SeqeraPlatformHelper.readReferenceFromObservers(new FakeSession(null)) == null
+        // not a session
+        SeqeraPlatformHelper.readReferenceFromObservers(new Object()) == null
+    }
+
+    /**
+     * Guards the field name against the real Nextflow class -- the fake above cannot catch a
+     * typo, because a wrong name and an absent one both resolve to null.
+     */
+    def 'the observer field it looks for exists on the real Session'() {
+        expect:
+        Session.getDeclaredField('observersV2') != null
+    }
+
     def 'reference type is Seqera'() {
         expect:
         SeqeraPlatformHelper.REFERENCE_TYPE == 'Seqera'

--- a/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
+++ b/src/test/groovy/ai/lamin/nf_lamin/util/SeqeraPlatformHelperTest.groovy
@@ -143,20 +143,13 @@ class SeqeraPlatformHelperTest extends Specification {
         SeqeraPlatformHelper.readReferenceFromObservers(new Object()) == null
     }
 
-    /**
-     * Guards the field name against the real Nextflow class -- the fake above cannot catch a
-     * typo, because a wrong name and an absent one both resolve to null.
-     */
+    /** Guards the field name against the real class -- the fake above cannot catch a typo. */
     def 'the observer field it looks for exists on the real Session'() {
         expect:
         Session.getDeclaredField('observersV2') != null
     }
 
-    /**
-     * Guards the getter names against the real Nextflow classes -- the fakes above cannot catch a
-     * typo, because a wrong name and an absent one both resolve to null. Skipped until the
-     * Nextflow floor is raised to 26.04.
-     */
+    /** Guards the getter names against the real classes; skipped until the floor is 26.04. */
     @Requires({ SeqeraPlatformHelperTest.platformMetadataClass() != null })
     def 'reads the real Nextflow PlatformMetadata'() {
         given:


### PR DESCRIPTION
Sets `run.reference` to the Seqera Platform watch URL and `run.reference_type` to `"Seqera"`, matching the existing Seqera runs on `laminlabs/lamindata`.

* On Nextflow 26.04+, the workflow.platform is read reflectively so the minimum version of nf-lamin can remain at 25.10
* On Nextflow 25.10, it falls back to reading the watch url straight off the nf-tower observer which keeps it in a private field, but ignores this if this would somehow fail.

Verified on prod with:

* `NXF_VER=25.10.5 make validate-legacy ARGS="-c configs/env-prod.config -with-tower"`
* `NXF_VER=26.04.6 make validate-run ARGS="-c configs/env-prod.config -with-tower`

Closes #80 and https://github.com/pfizer-collab/laminlabs/issues/464.
